### PR TITLE
Fix criterion bugs

### DIFF
--- a/pysatl_criterion/normal.py
+++ b/pysatl_criterion/normal.py
@@ -804,7 +804,7 @@ class ZhangWuANormalityGofStatistic(AbstractNormalityGofStatistic):
         if n > 3:
             phiz = np.zeros(n)
             mean_x = np.mean(rvs)
-            var_x = np.var(rvs)
+            var_x = np.var(rvs, ddof=1)
             sd_x = np.sqrt(var_x)
             for i in range(n):
                 phiz[i] = scipy_stats.norm.cdf((rvs[i] - mean_x) / sd_x)

--- a/pysatl_criterion/normal.py
+++ b/pysatl_criterion/normal.py
@@ -82,7 +82,7 @@ class AndersonDarlingNormalityGofStatistic(AbstractNormalityGofStatistic, ADStat
         xbar = np.mean(rvs, axis=0)
         w = (y - xbar) / s
         logcdf = scipy_stats.distributions.norm.logcdf(w)
-        logsf = scipy_stats.distributions.norm.logsf
+        logsf = scipy_stats.distributions.norm.logsf(w)
         return super().execute_statistic(rvs, log_cdf=logcdf, log_sf=logsf, w=w)
 
     @override

--- a/tests/normality_test.py
+++ b/tests/normality_test.py
@@ -1469,7 +1469,6 @@ def test_zhang_q_tar_normality_criterion_code():
         ),
     ],
 )
-@pytest.mark.skip(reason="no way of currently testing this")
 def test_zhang_wu_a_normality_criterion(data, result):
     statistic = ZhangWuANormalityGofStatistic().execute_statistic(data)
     assert result == pytest.approx(statistic, 0.00001)

--- a/tests/normality_test.py
+++ b/tests/normality_test.py
@@ -156,7 +156,6 @@ def test_ks_normality_criterion_code():
         ),
     ],
 )
-@pytest.mark.skip(reason="no way of currently testing this")
 def test_ad_normality_criterion(data, result):
     statistic = AndersonDarlingNormalityGofStatistic().execute_statistic(data)
     assert result == pytest.approx(statistic, 0.00001)


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant?
-->
## Summary
Fix incorrect executing stats in Anderson-Darling and Zhang-Wu statistics.

<!-- Explain in one sentence the goal of this PR --> Stats bug fix

## Quick changelog

-pysatl_criterion/normal.py
-tests/normality_test.py

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. --> Fix bugs in Anderson-Darling and Zhang-Wu statistics and make their tests unskipable
