### PR TITLE
Improve TestPyPI publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,3 +171,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true


### PR DESCRIPTION
## Summary

This PR stabilizes the CI/CD pipeline by improving the automated publishing flow to TestPyPI.

## Quick changelog

- Added `skip-existing: true` to TestPyPI deployment to prevent pipeline failures on duplicate versions.