### PR TITLE
Add bulk

### DIFF
--- a/pysatl_criterion/critical_value/loader/remote_loader.py
+++ b/pysatl_criterion/critical_value/loader/remote_loader.py
@@ -6,6 +6,7 @@ from pysatl_criterion.persistence.model.limit_distribution.limit_distribution im
     ILimitDistributionStorage,
 )
 
+logger = logging.getLogger(__name__)
 
 class CriticalValueLoader:
     def __init__(
@@ -35,16 +36,19 @@ class CriticalValueLoader:
             logging.error("Cannot load data: remote storage is not initialized.")
             return False
 
-        remote_data = self.__remote_storage.get_data_for_cv(query)
+        if self.__remote_storage.get_data_for_cv(query):
+            return True
 
+        remote_data = self.__remote_storage.get_data_for_cv(query)
         if remote_data is not None:
             self.__local_storage.insert_data(remote_data)
+            logger.debug(f"Loaded {criterion_code} (n={sample_size}) from remote.")
             return True
-        else:
-            logging.warning(
-                f"Remote data for criterion {criterion_code} with size {sample_size} not found"
-            )
-            return False
+
+        logging.warning(
+            f"Remote data for criterion {criterion_code} with size {sample_size} not found"
+        )
+        return False
 
     def load_bulk(
         self, criterion_codes: list[str], sample_size: int, sample_size_error: int = 0
@@ -58,6 +62,9 @@ class CriticalValueLoader:
         :return: BulkLoadResult containing counts of requested, cached, newly loaded, and not
         found criteria.
         """
+        if not criterion_codes:
+            return BulkLoadResult(0, 0, 0, [])
+
         if self.__remote_storage is None:
             logging.error("Remote storage not initialized.")
             return BulkLoadResult(len(criterion_codes), 0, 0, criterion_codes)
@@ -78,12 +85,18 @@ class CriticalValueLoader:
             return BulkLoadResult(len(criterion_codes), len(already_cached), 0)
 
         # 2. Fetch only missing data from remote
+        logger.info(f"Fetching {len(missing_codes)} missing criteria from remote...")
         remote_models = self.__remote_storage.get_bulk_data(
             missing_codes, sample_size, sample_size_error
         )
 
-        # 3. Save everything in one batch
-        self.__local_storage.insert_bulk_data(remote_models)
+        # 3. Bulk insert into local
+        try:
+            self.__local_storage.insert_bulk_data(remote_models)
+            logger.info(f"Successfully cached {len(remote_models)} new distributions.")
+        except Exception as e:
+            logger.error(f"Failed to save bulk data to local storage: {e}")
+            pass
 
         # 4. Calculate what's still missing (not found even on remote)
         found_codes = {m.criterion_code for m in remote_models}

--- a/pysatl_criterion/critical_value/loader/remote_loader.py
+++ b/pysatl_criterion/critical_value/loader/remote_loader.py
@@ -6,7 +6,9 @@ from pysatl_criterion.persistence.model.limit_distribution.limit_distribution im
     ILimitDistributionStorage,
 )
 
+
 logger = logging.getLogger(__name__)
+
 
 class CriticalValueLoader:
     def __init__(

--- a/pysatl_criterion/critical_value/loader/remote_loader.py
+++ b/pysatl_criterion/critical_value/loader/remote_loader.py
@@ -2,7 +2,7 @@ import logging
 
 from pysatl_criterion.persistence.model.limit_distribution.limit_distribution import (
     CriticalValueQuery,
-    ILimitDistributionStorage,
+    ILimitDistributionStorage, BulkLoadResult,
 )
 
 
@@ -44,3 +44,60 @@ class CriticalValueLoader:
                 f"Remote data for criterion {criterion_code} with size {sample_size} not found"
             )
             return False
+
+    def load_bulk(
+            self,
+            criterion_codes: list[str],
+            sample_size: int,
+            sample_size_error: int = 0
+    ) -> BulkLoadResult:
+        """
+        Synchronize multiple criteria with cache-miss optimization and bulk insert.
+
+        :param criterion_codes: list of criterion codes to load.
+        :param sample_size: sample size for the query.
+        :param sample_size_error: acceptable error in sample size for matching.
+        :return: BulkLoadResult containing counts of requested, cached, newly loaded, and not found criteria.
+        """
+        if self.__remote_storage is None:
+            logging.error("Remote storage not initialized.")
+            return BulkLoadResult(len(criterion_codes), 0, 0, criterion_codes)
+
+        # 1. Identify what's already in the local cache
+        already_cached = []
+        missing_codes = []
+
+        for code in criterion_codes:
+            query = CriticalValueQuery(code, sample_size, sample_size_error)
+            if self.__local_storage.get_data_for_cv(query):
+                already_cached.append(code)
+            else:
+                missing_codes.append(code)
+
+        if not missing_codes:
+            logging.info("All requested criteria are already in the local cache.")
+            return BulkLoadResult(len(criterion_codes), len(already_cached), 0)
+
+        # 2. Fetch only missing data from remote
+        remote_models = self.__remote_storage.get_bulk_data(
+            missing_codes, sample_size, sample_size_error
+        )
+
+        # 3. Save everything in one batch
+        self.__local_storage.insert_bulk_data(remote_models)
+
+        # 4. Calculate what's still missing (not found even on remote)
+        found_codes = {m.criterion_code for m in remote_models}
+        not_found = [c for c in missing_codes if c not in found_codes]
+
+        logging.info(
+            f"Bulk load finished: {len(remote_models)} new, "
+            f"{len(already_cached)} skipped, {len(not_found)} failed."
+        )
+
+        return BulkLoadResult(
+            requested_count=len(criterion_codes),
+            already_cached_count=len(already_cached),
+            newly_cached_count=len(remote_models),
+            not_found_codes=not_found
+        )

--- a/pysatl_criterion/critical_value/loader/remote_loader.py
+++ b/pysatl_criterion/critical_value/loader/remote_loader.py
@@ -1,8 +1,9 @@
 import logging
 
 from pysatl_criterion.persistence.model.limit_distribution.limit_distribution import (
+    BulkLoadResult,
     CriticalValueQuery,
-    ILimitDistributionStorage, BulkLoadResult,
+    ILimitDistributionStorage,
 )
 
 
@@ -46,10 +47,7 @@ class CriticalValueLoader:
             return False
 
     def load_bulk(
-            self,
-            criterion_codes: list[str],
-            sample_size: int,
-            sample_size_error: int = 0
+        self, criterion_codes: list[str], sample_size: int, sample_size_error: int = 0
     ) -> BulkLoadResult:
         """
         Synchronize multiple criteria with cache-miss optimization and bulk insert.
@@ -99,5 +97,5 @@ class CriticalValueLoader:
             requested_count=len(criterion_codes),
             already_cached_count=len(already_cached),
             newly_cached_count=len(remote_models),
-            not_found_codes=not_found
+            not_found_codes=not_found,
         )

--- a/pysatl_criterion/critical_value/loader/remote_loader.py
+++ b/pysatl_criterion/critical_value/loader/remote_loader.py
@@ -55,7 +55,8 @@ class CriticalValueLoader:
         :param criterion_codes: list of criterion codes to load.
         :param sample_size: sample size for the query.
         :param sample_size_error: acceptable error in sample size for matching.
-        :return: BulkLoadResult containing counts of requested, cached, newly loaded, and not found criteria.
+        :return: BulkLoadResult containing counts of requested, cached, newly loaded, and not
+        found criteria.
         """
         if self.__remote_storage is None:
             logging.error("Remote storage not initialized.")

--- a/pysatl_criterion/critical_value/resolver/composite_resolver.py
+++ b/pysatl_criterion/critical_value/resolver/composite_resolver.py
@@ -44,12 +44,19 @@ class CompositeCriticalValueResolver(CriticalValueResolver):
             load_result = self._cv_loader.load_bulk(missing, sample_size)
 
             if load_result.newly_cached_count > 0:
-                logger.info(f"Loaded {load_result.newly_cached_count} new criteria. Retrying local resolution...")
+                logger.info(
+                    f"Loaded {load_result.newly_cached_count} new criteria. "
+                    f"Retrying local resolution..."
+                )
                 codes_to_retry = [c for c in missing if c not in load_result.not_found_codes]
                 if codes_to_retry:
-                    new_results = self._local_resolver.resolve_bulk(codes_to_retry, sample_size, sl, alternative)
+                    new_results = self._local_resolver.resolve_bulk(
+                        codes_to_retry, sample_size, sl, alternative
+                    )
                     results.update(new_results)
             else:
-                logger.warning(f"Could not load any new data. Missing: {load_result.not_found_codes}")
+                logger.warning(
+                    f"Could not load any new data. Missing: {load_result.not_found_codes}"
+                )
 
         return results

--- a/pysatl_criterion/critical_value/resolver/composite_resolver.py
+++ b/pysatl_criterion/critical_value/resolver/composite_resolver.py
@@ -41,9 +41,15 @@ class CompositeCriticalValueResolver(CriticalValueResolver):
 
         # 3. Load missing results and update the results dictionary
         if missing:
-            for code in missing:
-                self._cv_loader.load(code, sample_size)
-            new_data = self._local_resolver.resolve_bulk(missing, sample_size, sl, alternative)
-            results.update(new_data)
+            load_result = self._cv_loader.load_bulk(missing, sample_size)
+
+            if load_result.newly_cached_count > 0:
+                logger.info(f"Loaded {load_result.newly_cached_count} new criteria. Retrying local resolution...")
+                codes_to_retry = [c for c in missing if c not in load_result.not_found_codes]
+                if codes_to_retry:
+                    new_results = self._local_resolver.resolve_bulk(codes_to_retry, sample_size, sl, alternative)
+                    results.update(new_results)
+            else:
+                logger.warning(f"Could not load any new data. Missing: {load_result.not_found_codes}")
 
         return results

--- a/pysatl_criterion/critical_value/resolver/composite_resolver.py
+++ b/pysatl_criterion/critical_value/resolver/composite_resolver.py
@@ -1,9 +1,12 @@
-from typing_extensions import override
+import logging
 
 from pysatl_criterion.critical_value.loader.remote_loader import CriticalValueLoader
 from pysatl_criterion.critical_value.resolver.model import CriticalArea, CriticalValueResolver
 from pysatl_criterion.critical_value.resolver.storage_resolver import StorageCriticalValueResolver
 from pysatl_criterion.statistics.models import HypothesisType
+
+
+logger = logging.getLogger(__name__)
 
 
 class CompositeCriticalValueResolver(CriticalValueResolver):
@@ -18,36 +21,29 @@ class CompositeCriticalValueResolver(CriticalValueResolver):
     ):
         self._local_resolver = local_resolver
         self._cv_loader = cv_loader
+        self._storage = local_resolver.limit_distribution_storage
 
-    @override
-    def resolve(
+    def resolve_bulk(
         self,
-        criterion_code: str,
+        criterion_codes: list[str],
         sample_size: int,
         sl: float,
         alternative: HypothesisType = HypothesisType.RIGHT,
-    ) -> CriticalArea | None:
+    ) -> dict[str, CriticalArea]:
         """
-        Resolve critical value for given criterion.
-            1. Try to get local value
-            2. Try to get remote value and cache it to local storage.
-
-        :param criterion_code: criterion code.
-        :param sample_size: sample size.
-        :param sl: significance level.
-        :param alternative: test alternative
-
-        :return: critical value.
+        Resolve multiple critical values using cache and bulk loader.
         """
+        # 1. Get all local results
+        results = self._local_resolver.resolve_bulk(criterion_codes, sample_size, sl, alternative)
 
-        # 1. Try to get local value
-        result = self._local_resolver.resolve(criterion_code, sample_size, sl, alternative)
+        # 2. Search for missing results
+        missing = [c for c in criterion_codes if c not in results]
 
-        if result is not None:
-            return result
+        # 3. Load missing results and update the results dictionary
+        if missing:
+            for code in missing:
+                self._cv_loader.load(code, sample_size)
+            new_data = self._local_resolver.resolve_bulk(missing, sample_size, sl, alternative)
+            results.update(new_data)
 
-        # 2. Try to get remote value and cache it to local storage.
-        if self._cv_loader.load(criterion_code, sample_size):
-            return self._local_resolver.resolve(criterion_code, sample_size, sl, alternative)
-
-        return None
+        return results

--- a/pysatl_criterion/critical_value/resolver/model.py
+++ b/pysatl_criterion/critical_value/resolver/model.py
@@ -9,7 +9,6 @@ class CriticalValueResolver(ABC):
     Critical value calculator interface. Calculate critical area.
     """
 
-    @abstractmethod
     def resolve(
         self,
         criterion_code: str,
@@ -26,5 +25,25 @@ class CriticalValueResolver(ABC):
         :param alternative: test alternative
 
         :return: critical value if critical value exists, None otherwise
+        """
+
+        return self.resolve_bulk([criterion_code], sample_size, sl, alternative).get(criterion_code)
+
+    @abstractmethod
+    def resolve_bulk(
+        self,
+        criterion_codes: list[str],
+        sample_size: int,
+        sl: float,
+        alternative: HypothesisType = HypothesisType.RIGHT,
+    ) -> dict[str, CriticalArea]:
+        """
+        Resolve multiple critical areas for a fixed sample size and alpha.
+
+        :param criterion_codes: list of criterion identifiers.
+        :param sample_size: target sample size.
+        :param sl: significance level.
+        :param alternative: test alternative.
+        :return: dictionary mapping codes to critical areas.
         """
         pass

--- a/pysatl_criterion/critical_value/resolver/storage_resolver.py
+++ b/pysatl_criterion/critical_value/resolver/storage_resolver.py
@@ -10,7 +10,6 @@ from pysatl_criterion.critical_value.critical_area.critical_areas import (
 from pysatl_criterion.critical_value.critical_area.model import CriticalArea
 from pysatl_criterion.critical_value.resolver.model import CriticalValueResolver
 from pysatl_criterion.persistence.model.limit_distribution.limit_distribution import (
-    CriticalValueQuery,
     ILimitDistributionStorage,
 )
 from pysatl_criterion.statistics.models import HypothesisType
@@ -27,32 +26,37 @@ class StorageCriticalValueResolver(CriticalValueResolver):
         self.limit_distribution_storage = limit_distribution_storage
 
     @override
-    def resolve(
+    def resolve_bulk(
         self,
-        criterion_code: str,
+        criterion_codes: list[str],
         sample_size: int,
         sl: float,
         alternative: HypothesisType = HypothesisType.RIGHT,
-    ) -> CriticalArea | None:
+    ) -> dict[str, CriticalArea]:
         """
-        Resolver critical value for given criterion from storage.
+        Bulk resolver critical values for given criteria from storage.
 
-        :param criterion_code: criterion code
+        :param criterion_codes: list of criterion codes
         :param sample_size: sample size
         :param sl: significance level
         :param alternative: test alternative
 
-        :return: critical value if critical value exists, None otherwise
+        :return: dict of criterion code to critical value for criteria with existing critical values
         """
 
-        query = CriticalValueQuery(criterion_code=criterion_code, sample_size=sample_size)
-        limit_distribution = self.limit_distribution_storage.get_data_for_cv(query)
+        limit_distributions = self.limit_distribution_storage.get_bulk_data(
+            criterion_codes, sample_size
+        )
 
-        if limit_distribution is None:
-            return None
+        results = {}
+        for d in limit_distributions:
+            ecdf = scipy_stats.ecdf(d.results_statistics)
+            area = self._calculate_area(ecdf, sl, alternative)
+            if area:
+                results[d.criterion_code] = area
+        return results
 
-        ecdf = scipy_stats.ecdf(limit_distribution.results_statistics)
-
+    def _calculate_area(self, ecdf, sl, alternative) -> CriticalArea:
         if alternative == HypothesisType.RIGHT:
             return RightCriticalArea(float(np.quantile(ecdf.cdf.quantiles, q=1 - sl)))
         elif alternative == HypothesisType.LEFT:
@@ -61,5 +65,4 @@ class StorageCriticalValueResolver(CriticalValueResolver):
             left = float(np.quantile(ecdf.cdf.quantiles, q=sl / 2))
             right = float(np.quantile(ecdf.cdf.quantiles, q=1 - sl / 2))
             return TwoSidedCriticalArea(left, right)
-        else:
-            raise ValueError(f"Unknown alternative: {alternative}.")
+        raise ValueError(f"Unknown alternative: {alternative}.")

--- a/pysatl_criterion/persistence/limit_distribution/datastorage/datastorage.py
+++ b/pysatl_criterion/persistence/limit_distribution/datastorage/datastorage.py
@@ -86,6 +86,47 @@ class AlchemyLimitDistributionStorage(ILimitDistributionStorage):
             result = session.execute(stmt).scalar_one_or_none()
             return result.to_model() if result else None
 
+    def get_bulk_data(
+            self,
+            criterion_codes: list[str],
+            sample_size: int,
+            sample_size_error: int = 0
+    ) -> list[LimitDistributionModel]:
+        """
+        Fetch multiple limit distributions by their codes and sample size range.
+
+        :param criterion_codes: list of unique criterion identifiers.
+        :param sample_size: target sample size.
+        :param sample_size_error: allowed deviation for sample size.
+        :return: list of found LimitDistributionModel objects.
+        """
+        with self.Session() as session:
+            min_size = sample_size - sample_size_error
+            max_size = sample_size + sample_size_error
+
+            stmt = select(LimitDistributionORM).where(
+                LimitDistributionORM.criterion_code.in_(criterion_codes),
+                LimitDistributionORM.sample_size.between(min_size, max_size)
+            )
+
+            results = session.execute(stmt).scalars().all()
+            return [result.to_model() for result in results]
+
+    def insert_bulk_data(self, models: list[LimitDistributionModel]) -> None:
+        """
+        Insert multiple records into the database in a single transaction.
+
+        :param models: list of models to be persisted.
+        """
+        if not models:
+            return
+
+        with self.Session() as session:
+            for model in models:
+                orm_obj = LimitDistributionORM.from_model(model)
+                session.merge(orm_obj)
+            session.commit()
+
     def delete_data(self, query: LimitDistributionQuery) -> None:
         """
         Delete limit distribution data based on the provided query parameters.

--- a/pysatl_criterion/persistence/limit_distribution/datastorage/datastorage.py
+++ b/pysatl_criterion/persistence/limit_distribution/datastorage/datastorage.py
@@ -107,7 +107,17 @@ class AlchemyLimitDistributionStorage(ILimitDistributionStorage):
             )
 
             results = session.execute(stmt).scalars().all()
-            return [result.to_model() for result in results]
+
+            best_results: dict[str, LimitDistributionModel] = {}
+            for obj in results:
+                key = obj.criterion_code
+                if (
+                    key not in best_results
+                    or obj.monte_carlo_count > best_results[key].monte_carlo_count
+                ):
+                    best_results[key] = obj.to_model()
+
+            return list(best_results.values())
 
     def insert_bulk_data(self, models: list[LimitDistributionModel]) -> None:
         """

--- a/pysatl_criterion/persistence/limit_distribution/datastorage/datastorage.py
+++ b/pysatl_criterion/persistence/limit_distribution/datastorage/datastorage.py
@@ -87,10 +87,7 @@ class AlchemyLimitDistributionStorage(ILimitDistributionStorage):
             return result.to_model() if result else None
 
     def get_bulk_data(
-            self,
-            criterion_codes: list[str],
-            sample_size: int,
-            sample_size_error: int = 0
+        self, criterion_codes: list[str], sample_size: int, sample_size_error: int = 0
     ) -> list[LimitDistributionModel]:
         """
         Fetch multiple limit distributions by their codes and sample size range.
@@ -106,7 +103,7 @@ class AlchemyLimitDistributionStorage(ILimitDistributionStorage):
 
             stmt = select(LimitDistributionORM).where(
                 LimitDistributionORM.criterion_code.in_(criterion_codes),
-                LimitDistributionORM.sample_size.between(min_size, max_size)
+                LimitDistributionORM.sample_size.between(min_size, max_size),
             )
 
             results = session.execute(stmt).scalars().all()

--- a/pysatl_criterion/persistence/model/limit_distribution/limit_distribution.py
+++ b/pysatl_criterion/persistence/model/limit_distribution/limit_distribution.py
@@ -13,10 +13,12 @@ class BulkLoadResult:
     """
     Detailed statistics for the bulk load operation.
     """
+
     requested_count: int
     already_cached_count: int
     newly_cached_count: int
     not_found_codes: list[str] = field(default_factory=list)
+
 
 @dataclass
 class LimitDistributionModel(DataModel):
@@ -72,7 +74,8 @@ class ILimitDistributionStorage(IDataStorage[LimitDistributionModel, LimitDistri
         pass
 
     @abstractmethod
-    def get_bulk_data(self, criterion_codes: list[str], sample_size: int, sample_size_error: int = 0
+    def get_bulk_data(
+        self, criterion_codes: list[str], sample_size: int, sample_size_error: int = 0
     ) -> list[LimitDistributionModel]:
         """
         Fetch multiple limit distributions using a batch query.

--- a/pysatl_criterion/persistence/model/limit_distribution/limit_distribution.py
+++ b/pysatl_criterion/persistence/model/limit_distribution/limit_distribution.py
@@ -6,6 +6,7 @@ from pysatl_criterion.persistence.model.common.data_storage.data_storage import 
     DataQuery,
     IDataStorage,
 )
+from pysatl_criterion.statistics.models import HypothesisType
 
 
 @dataclass
@@ -18,6 +19,20 @@ class BulkLoadResult:
     already_cached_count: int
     newly_cached_count: int
     not_found_codes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CriticalValueResultModel(DataModel):
+    """
+    Model for storing calculated critical values.
+    """
+
+    criterion_code: str
+    sample_size: int
+    significance_level: float
+    alternative: HypothesisType
+    value_low: float
+    value_high: float | None = None
 
 
 @dataclass

--- a/pysatl_criterion/persistence/model/limit_distribution/limit_distribution.py
+++ b/pysatl_criterion/persistence/model/limit_distribution/limit_distribution.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pysatl_criterion.persistence.model.common.data_storage.data_storage import (
     DataModel,
@@ -7,6 +7,16 @@ from pysatl_criterion.persistence.model.common.data_storage.data_storage import 
     IDataStorage,
 )
 
+
+@dataclass
+class BulkLoadResult:
+    """
+    Detailed statistics for the bulk load operation.
+    """
+    requested_count: int
+    already_cached_count: int
+    newly_cached_count: int
+    not_found_codes: list[str] = field(default_factory=list)
 
 @dataclass
 class LimitDistributionModel(DataModel):
@@ -56,8 +66,29 @@ class ILimitDistributionStorage(IDataStorage[LimitDistributionModel, LimitDistri
         Get limit distribution data for critical value calculation.
 
         :param query: calculation parameters.
-
         :return: limit distribution data.
         """
 
+        pass
+
+    @abstractmethod
+    def get_bulk_data(self, criterion_codes: list[str], sample_size: int, sample_size_error: int = 0
+    ) -> list[LimitDistributionModel]:
+        """
+        Fetch multiple limit distributions using a batch query.
+
+        :param criterion_codes: list of criterion codes.
+        :param sample_size: number of samples.
+        :param sample_size_error: number of samples error.
+        :return: list of limit distribution data.
+        """
+        pass
+
+    @abstractmethod
+    def insert_bulk_data(self, models: list[LimitDistributionModel]) -> None:
+        """
+        Batch insert or update multiple distribution records.
+
+        :param models: list of limit distribution data.
+        """
         pass

--- a/pysatl_criterion/persistence/model/limit_distribution/limit_distribution.py
+++ b/pysatl_criterion/persistence/model/limit_distribution/limit_distribution.py
@@ -6,7 +6,6 @@ from pysatl_criterion.persistence.model.common.data_storage.data_storage import 
     DataQuery,
     IDataStorage,
 )
-from pysatl_criterion.statistics.models import HypothesisType
 
 
 @dataclass
@@ -19,20 +18,6 @@ class BulkLoadResult:
     already_cached_count: int
     newly_cached_count: int
     not_found_codes: list[str] = field(default_factory=list)
-
-
-@dataclass
-class CriticalValueResultModel(DataModel):
-    """
-    Model for storing calculated critical values.
-    """
-
-    criterion_code: str
-    sample_size: int
-    significance_level: float
-    alternative: HypothesisType
-    value_low: float
-    value_high: float | None = None
 
 
 @dataclass

--- a/pysatl_criterion/persistence/model/orm/orm.py
+++ b/pysatl_criterion/persistence/model/orm/orm.py
@@ -1,12 +1,15 @@
 import json
 
-from sqlalchemy import PrimaryKeyConstraint, Text
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy import Float, Integer, PrimaryKeyConstraint, Text
 from sqlalchemy.orm import Mapped, declarative_base, mapped_column
 
 from pysatl_criterion.persistence.alchemy_decorator import CompressedFloatArray
 from pysatl_criterion.persistence.model.limit_distribution.limit_distribution import (
+    CriticalValueResultModel,
     LimitDistributionModel,
 )
+from pysatl_criterion.statistics.models import HypothesisType
 
 
 Base = declarative_base()

--- a/pysatl_criterion/persistence/model/orm/orm.py
+++ b/pysatl_criterion/persistence/model/orm/orm.py
@@ -1,15 +1,12 @@
 import json
 
-from sqlalchemy import Enum as SQLEnum
-from sqlalchemy import Float, Integer, PrimaryKeyConstraint, Text
+from sqlalchemy import PrimaryKeyConstraint, Text
 from sqlalchemy.orm import Mapped, declarative_base, mapped_column
 
 from pysatl_criterion.persistence.alchemy_decorator import CompressedFloatArray
 from pysatl_criterion.persistence.model.limit_distribution.limit_distribution import (
-    CriticalValueResultModel,
     LimitDistributionModel,
 )
-from pysatl_criterion.statistics.models import HypothesisType
 
 
 Base = declarative_base()

--- a/pysatl_criterion/test/goodness_of_fit_test/goodness_of_fit_test.py
+++ b/pysatl_criterion/test/goodness_of_fit_test/goodness_of_fit_test.py
@@ -27,14 +27,14 @@ class GoodnessOfFitTest:
 
     def __init__(
         self,
-        statistics: AbstractGoodnessOfFitStatistic,
+        statistics: list[AbstractGoodnessOfFitStatistic],
         significance_level: float,
         cv_resolver: CriticalValueResolver | None = None,
         p_value_resolver: PValueResolver | None = None,
         test_method: TestMethod = TestMethod.CRITICAL_VALUE,
         alternative: HypothesisType = HypothesisType.RIGHT,
     ):
-        self.statistics = statistics
+        self.statistics_list = statistics
         self.significance_level = significance_level
         self.test_method = test_method
         self.alternative = alternative
@@ -69,43 +69,38 @@ class GoodnessOfFitTest:
         self.cv_calculator = cv_resolver
         self.p_value_resolver = p_value_resolver
 
-    def test(self, data: list[float]) -> bool:
+    def test(self, data: list[float]) -> dict[str, bool]:
         """
         Perform goodness of fit.
 
         :param data: data to test.
 
-        :return: True if data is fitted distribution, False otherwise.
+        :return: a dictionary mapping criterion code to test result (True/False).
         """
 
         data_size = len(data)
-        criterion_code = self.statistics.code()
-        statistics_value = self.statistics.execute_statistic(data)
+        stats_map = {s.code(): s.execute_statistic(data) for s in self.statistics_list}
+        codes = list(stats_map.keys())
 
         if self.cv_calculator and self.test_method == TestMethod.CRITICAL_VALUE:
-            critical_area = self.cv_calculator.resolve(
-                criterion_code,
-                data_size,
-                self.significance_level,
-                self.alternative,
+            critical_areas = self.cv_calculator.resolve_bulk(
+                codes, data_size, self.significance_level, self.alternative
             )
-
-            if critical_area is None:
-                raise ValueError(
-                    f"Limit distribution for criterion {criterion_code} and "
-                    f"sample size {data_size} does not exist."
+            return {
+                code: (
+                    critical_areas[code].contains(stats_map[code])
+                    if code in critical_areas
+                    else False
                 )
-
-            return critical_area.contains(statistics_value)
+                for code in codes
+            }
 
         elif self.p_value_resolver and self.test_method == TestMethod.P_VALUE:
-            p_value = self.p_value_resolver.resolve(
-                criterion_code,
-                data_size,
-                statistics_value,
-                self.alternative,
-            )
+            results = {}
+            for code, stat in stats_map.items():
+                p_value = self.p_value_resolver.resolve(code, data_size, stat, self.alternative)
+                results[code] = p_value is not None and p_value >= self.significance_level
+            return results
 
-            return p_value is not None and p_value >= self.significance_level
         else:
             raise ValueError(f"Invalid test method {self.test_method}.")

--- a/tests/calc/test_goodness_of_fit_test.py
+++ b/tests/calc/test_goodness_of_fit_test.py
@@ -1,6 +1,9 @@
 from unittest.mock import MagicMock, patch
 
 from pysatl_criterion.critical_value.critical_area.critical_areas import RightCriticalArea
+from pysatl_criterion.critical_value.resolver.composite_resolver import (
+    CompositeCriticalValueResolver,
+)
 from pysatl_criterion.statistics.models import HypothesisType
 from pysatl_criterion.test.goodness_of_fit_test.goodness_of_fit_test import GoodnessOfFitTest
 from pysatl_criterion.test.model import TestMethod
@@ -15,17 +18,23 @@ def test_goodness_of_fit_cv_path_accepts_hypothesis(mock_stat_cls, mock_cv_cls):
     mock_stat.execute_statistic.return_value = 10.0
 
     mock_cv = mock_cv_cls.return_value
-    mock_cv.resolve.return_value = MagicMock(contains=lambda x: x < 15.0)
+    mock_area = RightCriticalArea(15.0)
+    mock_cv.resolve_bulk.return_value = {"test_criterion": mock_area}
 
     gof_test = GoodnessOfFitTest(
-        statistics=mock_stat,
+        statistics=[mock_stat],
         significance_level=0.05,
         test_method=TestMethod.CRITICAL_VALUE,
         alternative=HypothesisType.RIGHT,
         cv_resolver=mock_cv,
     )
 
-    assert gof_test.test(data=[1, 2, 3]) is True
+    # Act
+    result_dict = gof_test.test(data=[1, 2, 3])
+
+    # Assert
+    assert isinstance(result_dict, dict)
+    assert result_dict["test_criterion"] is True
 
 
 @patch("pysatl_criterion.critical_value.resolver.model.CriticalValueResolver")
@@ -36,17 +45,23 @@ def test_goodness_of_fit_cv_path_rejects_hypothesis(mock_stat_cls, mock_cv_cls):
     mock_stat.execute_statistic.return_value = 10.0
 
     mock_cv = mock_cv_cls.return_value
-    mock_cv.resolve.return_value = RightCriticalArea(9)
+    mock_area = RightCriticalArea(9.0)
+    mock_cv.resolve_bulk.return_value = {"test_criterion": mock_area}
 
     gof_test = GoodnessOfFitTest(
-        statistics=mock_stat,
+        statistics=[mock_stat],
         significance_level=0.05,
         test_method=TestMethod.CRITICAL_VALUE,
         alternative=HypothesisType.RIGHT,
         cv_resolver=mock_cv,
     )
 
-    assert gof_test.test(data=[1, 2, 3]) is False
+    # Act
+    result_dict = gof_test.test(data=[1, 2, 3])
+
+    # Assert
+    assert isinstance(result_dict, dict)
+    assert result_dict["test_criterion"] is False
 
 
 @patch("pysatl_criterion.p_value.resolver.model.PValueResolver")
@@ -60,13 +75,18 @@ def test_goodness_of_fit_p_value_path_accepts_hypothesis(mock_stat_cls, mock_p_v
     mock_p_value.resolve.return_value = 0.1
 
     gof_test = GoodnessOfFitTest(
-        statistics=mock_stat,
+        statistics=[mock_stat],
         significance_level=0.05,
         test_method=TestMethod.P_VALUE,
         p_value_resolver=mock_p_value,
     )
 
-    assert gof_test.test(data=[1, 2, 3]) is True
+    # Act
+    result_dict = gof_test.test(data=[1, 2, 3])
+
+    # Assert
+    assert isinstance(result_dict, dict)
+    assert result_dict["test_criterion"] is True
 
 
 @patch("pysatl_criterion.p_value.resolver.model.PValueResolver")
@@ -80,28 +100,34 @@ def test_goodness_of_fit_p_value_path_rejects_hypothesis(mock_stat_cls, mock_p_v
     mock_p_value.resolve.return_value = 0.01
 
     gof_test = GoodnessOfFitTest(
-        p_value_resolver=mock_p_value,
-        statistics=mock_stat,
+        statistics=[mock_stat],
         significance_level=0.05,
         test_method=TestMethod.P_VALUE,
+        p_value_resolver=mock_p_value,
     )
 
-    assert gof_test.test(data=[1, 2, 3]) is False
+    # Act
+    result_dict = gof_test.test(data=[1, 2, 3])
+
+    # Assert
+    assert isinstance(result_dict, dict)
+    assert result_dict["test_criterion"] is False
 
 
-def test_goodness_of_fit_default_resolver_initialization():
-    """
-    Ensure that the test correctly initializes the Composite resolver
-    when no external resolver is provided.
-    """
+@patch(
+    "pysatl_criterion.test.goodness_of_fit_test.goodness_of_fit_test."
+    "AlchemyLimitDistributionStorage"
+)
+def test_goodness_of_fit_default_resolver_initialization(mock_storage_cls):
+    mock_instance = MagicMock()
+    mock_storage_cls.create_safe.return_value = mock_instance
+
     mock_stat = MagicMock()
+    mock_stat.code.return_value = "dummy_code"
 
     gof_test = GoodnessOfFitTest(
-        statistics=mock_stat, significance_level=0.05, test_method=TestMethod.CRITICAL_VALUE
-    )
-
-    from pysatl_criterion.critical_value.resolver.composite_resolver import (
-        CompositeCriticalValueResolver,
+        statistics=[mock_stat], significance_level=0.05, test_method=TestMethod.CRITICAL_VALUE
     )
 
     assert isinstance(gof_test.cv_calculator, CompositeCriticalValueResolver)
+    assert mock_storage_cls.create_safe.called

--- a/tests/critical_value/test_composite_resolver.py
+++ b/tests/critical_value/test_composite_resolver.py
@@ -4,58 +4,105 @@ from pysatl_criterion.critical_value.critical_area.critical_areas import RightCr
 from pysatl_criterion.critical_value.resolver.composite_resolver import (
     CompositeCriticalValueResolver,
 )
-from pysatl_criterion.statistics.models import HypothesisType
+from pysatl_criterion.persistence.model.limit_distribution.limit_distribution import BulkLoadResult
 
 
-def test_composite_resolver_cache_miss_logic():
+def test_composite_resolver_cache_hit():
     """
-    Scenario:
-    1. Local resolver returns None (cache miss).
-    2. Loader successfully fetches data (returns True).
-    3. Local resolver is called again and returns the area.
+    All data is in local cache. Loader should NOT be called.
     """
-    # Setup mocks
     mock_local_resolver = MagicMock()
     mock_loader = MagicMock()
 
-    expected_area = RightCriticalArea(1.96)
+    code1 = "crit1"
+    area1 = RightCriticalArea(1.96)
 
-    mock_local_resolver.resolve.side_effect = [None, expected_area]
+    mock_local_resolver.resolve_bulk.return_value = {code1: area1}
 
-    mock_loader.load.return_value = True
+    resolver = CompositeCriticalValueResolver(mock_local_resolver, mock_loader)
 
-    resolver = CompositeCriticalValueResolver(
-        local_resolver=mock_local_resolver, cv_loader=mock_loader
+    results = resolver.resolve_bulk([code1], 100, 0.05)
+
+    assert results == {code1: area1}
+    mock_loader.load_bulk.assert_not_called()
+    assert mock_local_resolver.resolve_bulk.call_count == 1
+
+
+def test_composite_resolver_cache_miss_and_load_success():
+    """
+    1. Local cache miss.
+    2. Loader successfully fetches data.
+    3. Second local call returns the data.
+    """
+    mock_local_resolver = MagicMock()
+    mock_loader = MagicMock()
+
+    code1 = "crit1"
+    area1 = RightCriticalArea(1.96)
+
+    mock_local_resolver.resolve_bulk.side_effect = [{}, {code1: area1}]
+
+    mock_loader.load_bulk.return_value = BulkLoadResult(
+        requested_count=1, already_cached_count=0, newly_cached_count=1, not_found_codes=[]
     )
 
-    # Act
-    result = resolver.resolve(
-        criterion_code="test_crit", sample_size=100, sl=0.05, alternative=HypothesisType.RIGHT
-    )
+    resolver = CompositeCriticalValueResolver(mock_local_resolver, mock_loader)
 
-    # Assert
-    assert mock_local_resolver.resolve.call_count == 2
-    mock_loader.load.assert_called_once_with("test_crit", 100)
-    assert result == expected_area
+    results = resolver.resolve_bulk([code1], 100, 0.05)
+
+    assert results == {code1: area1}
+    assert mock_local_resolver.resolve_bulk.call_count == 2
+    mock_loader.load_bulk.assert_called_once_with([code1], 100)
 
 
 def test_composite_resolver_loader_fails():
     """
-    If loader return False, there should be no second attempt to search the local database
+    Loader returns failure (not_found). Result should be empty for that code.
     """
-    # Setup mocks
     mock_local_resolver = MagicMock()
     mock_loader = MagicMock()
 
-    mock_local_resolver.resolve.return_value = None
-    mock_loader.load.return_value = False  # Данных нет на сервере
+    code1 = "crit1"
+
+    mock_local_resolver.resolve_bulk.side_effect = [{}, {}]
+
+    mock_loader.load_bulk.return_value = BulkLoadResult(
+        requested_count=1, already_cached_count=0, newly_cached_count=0, not_found_codes=[code1]
+    )
 
     resolver = CompositeCriticalValueResolver(mock_local_resolver, mock_loader)
 
-    # Act
-    result = resolver.resolve("test_crit", 100, 0.05)
+    results = resolver.resolve_bulk([code1], 100, 0.05)
 
-    # Assert
-    assert mock_local_resolver.resolve.call_count == 1
-    mock_loader.load.assert_called_once()
-    assert result is None
+    assert code1 not in results
+    assert mock_local_resolver.resolve_bulk.call_count == 1
+    mock_loader.load_bulk.assert_called_once()
+
+
+def test_composite_resolver_partial_cache_hit():
+    """
+    Some codes in cache, some missing. Only missing are loaded.
+    """
+
+    mock_local_resolver = MagicMock()
+    mock_loader = MagicMock()
+
+    code1 = "crit1"
+    code2 = "crit2"
+    area1 = RightCriticalArea(1.96)
+    area2 = RightCriticalArea(2.58)
+
+    mock_local_resolver.resolve_bulk.side_effect = [{code1: area1}, {code2: area2}]
+
+    mock_loader.load_bulk.return_value = BulkLoadResult(
+        requested_count=1, already_cached_count=0, newly_cached_count=1, not_found_codes=[]
+    )
+
+    resolver = CompositeCriticalValueResolver(mock_local_resolver, mock_loader)
+
+    results = resolver.resolve_bulk([code1, code2], 100, 0.05)
+
+    assert results == {code1: area1, code2: area2}
+    assert mock_local_resolver.resolve_bulk.call_count == 2
+
+    mock_loader.load_bulk.assert_called_once_with([code2], 100)

--- a/tests/critical_value/test_remote_loader.py
+++ b/tests/critical_value/test_remote_loader.py
@@ -275,3 +275,91 @@ def test_alchemy_storage_create_safe_on_failure():
     storage = AlchemyLimitDistributionStorage.create_safe(bad_url, label="Broken DB")
 
     assert storage is None
+
+def test_load_bulk_all_new_data(loader, local_storage, remote_storage):
+    """
+    Test the load_bulk method when all requested criteria are missing from local storage and found in remote storage.
+    """
+    # Arrange
+    criterion_codes = ["ks", "ad"]
+    sample_size = 100
+    models = [
+        LimitDistributionModel(1, "ks", [], sample_size, 1000, [0.1]),
+        LimitDistributionModel(2, "ad", [], sample_size, 1000, [0.2]),
+    ]
+    for model in models:
+        remote_storage.insert_data(model)
+
+    # Act
+    result = loader.load_bulk(criterion_codes, sample_size)
+
+    # Assert
+    assert result.requested_count == len(criterion_codes)
+    assert result.already_cached_count == 0
+    assert result.newly_cached_count == len(criterion_codes)
+    assert result.not_found_codes == []
+
+    for model in models:
+        query = CriticalValueQuery(
+            criterion_code=model.criterion_code, sample_size=model.sample_size
+        )
+        local_data = local_storage.get_data_for_cv(query)
+        assert local_data is not None
+        assert np.allclose(
+            local_data.results_statistics, model.results_statistics, rtol=1e-7, atol=0.0
+        )
+
+
+def test_load_bulk_with_partial_cache(loader, local_storage, remote_storage):
+    """
+    Test the load_bulk method when some criteria are already in local storage and some are missing.
+    """
+    # Arrange
+    criterion_codes = ["ks", "ad"]
+    sample_size = 100
+
+    local_model_ks = LimitDistributionModel(1, "ks", [], sample_size, 1000, [0.1])
+    local_storage.insert_data(local_model_ks)
+
+    remote_model_ad = LimitDistributionModel(2, "ad", [], sample_size, 1000, [0.2])
+    remote_storage.insert_data(remote_model_ad)
+
+    # Act
+    result = loader.load_bulk(criterion_codes, sample_size)
+
+    # Assert
+    assert result.requested_count == len(criterion_codes)
+    assert result.already_cached_count == 1
+    assert result.newly_cached_count == 1
+    assert result.not_found_codes == []
+
+    query_ad = CriticalValueQuery(criterion_code="ad", sample_size=sample_size)
+    local_data_ad = local_storage.get_data_for_cv(query_ad)
+    assert local_data_ad is not None
+    assert np.allclose(
+        local_data_ad.results_statistics,
+        remote_model_ad.results_statistics,
+    )
+
+
+def test_load_bulk_remote_not_found(loader, local_storage, remote_storage):
+    """
+    Test the load_bulk method when none of the requested criteria are found in remote and local storages.
+    """
+    # Arrange
+    criterion_codes = ["code1", "code2"]
+    sample_size = 100
+
+    # Act
+    result = loader.load_bulk(criterion_codes, sample_size)
+
+    # Assert
+    assert result.requested_count == len(criterion_codes)
+    assert result.already_cached_count == 0
+    assert result.newly_cached_count == 0
+    assert sorted(result.not_found_codes) == sorted(criterion_codes)
+
+    for code in criterion_codes:
+        query = CriticalValueQuery(criterion_code=code, sample_size=sample_size)
+        local_data = local_storage.get_data_for_cv(query)
+        assert local_data is None

--- a/tests/critical_value/test_remote_loader.py
+++ b/tests/critical_value/test_remote_loader.py
@@ -35,258 +35,17 @@ def loader(local_storage, remote_storage):
     return CriticalValueLoader(local_storage, remote_storage)
 
 
-@pytest.fixture
-def sample_query():
-    """Create a sample CriticalValueQuery for testing."""
-    return CriticalValueQuery(criterion_code="test_criterion", sample_size=100)
-
-
-@pytest.fixture
-def sample_model():
-    """Create a sample LimitDistributionModel for testing."""
-    return LimitDistributionModel(
-        experiment_id=1,
-        criterion_code="test_criterion",
-        criterion_parameters=[1.0, 2.0],
-        sample_size=100,
-        monte_carlo_count=1000,
-        results_statistics=[0.1, 0.2, 0.3, 0.4, 0.5],
-    )
-
-
-def test_load_success_with_remote_data(
-    loader, sample_query, sample_model, remote_storage, local_storage
-):
-    """Test load function when remote data is found and successfully inserted to local storage."""
-    # Arrange - insert data into remote storage
-    remote_storage.insert_data(sample_model)
-
-    # Act
-    result = loader.load(sample_query.criterion_code, sample_query.sample_size)
-
-    # Assert - verify data was copied to local storage
-    local_data = local_storage.get_data_for_cv(sample_query)
-    assert local_data is not None
-    assert local_data.criterion_code == sample_model.criterion_code
-    assert local_data.sample_size == sample_model.sample_size
-    assert np.allclose(
-        local_data.results_statistics, sample_model.results_statistics, rtol=1e-7, atol=0.0
-    )
-    assert result is True
-
-
-def test_load_no_remote_data(loader, sample_query, local_storage):
-    """Test load function when remote data is not found (returns None)."""
-    # Act
-    result = loader.load(sample_query.criterion_code, sample_query.sample_size)
-
-    # Assert - verify no data was inserted into local storage
-    local_data = local_storage.get_data_for_cv(sample_query)
-    assert local_data is None
-    assert result is False
-
-
-def test_load_storage_interactions_correct_order(
-    loader, sample_query, sample_model, remote_storage, local_storage
-):
-    """Test that storage methods are called in the correct order and data flows correctly."""
-    # Arrange
-    remote_storage.insert_data(sample_model)
-
-    # Act
-    loader.load(sample_query.criterion_code, sample_query.sample_size)
-
-    # Assert - verify data exists in both storages
-    remote_data = remote_storage.get_data_for_cv(sample_query)
-    local_data = local_storage.get_data_for_cv(sample_query)
-
-    assert remote_data is not None
-    assert local_data is not None
-    assert local_data.results_statistics == remote_data.results_statistics
-
-
-def test_load_with_different_query_parameters(loader, remote_storage, local_storage):
-    """Test load function with different query parameters."""
-    # Test with different criterion codes and sample sizes
-    test_cases = [
-        (
-            CriticalValueQuery(criterion_code="ks_test", sample_size=50),
-            LimitDistributionModel(
-                experiment_id=1,
-                criterion_code="ks_test",
-                criterion_parameters=[],
-                sample_size=50,
-                monte_carlo_count=1000,
-                results_statistics=[0.1, 0.2, 0.3],
-            ),
-        ),
-        (
-            CriticalValueQuery(criterion_code="ad_test", sample_size=200),
-            LimitDistributionModel(
-                experiment_id=1,
-                criterion_code="ad_test",
-                criterion_parameters=[],
-                sample_size=200,
-                monte_carlo_count=1000,
-                results_statistics=[0.4, 0.5, 0.6],
-            ),
-        ),
-        (
-            CriticalValueQuery(criterion_code="cvm_test", sample_size=1000),
-            LimitDistributionModel(
-                experiment_id=1,
-                criterion_code="cvm_test",
-                criterion_parameters=[],
-                sample_size=1000,
-                monte_carlo_count=1000,
-                results_statistics=[0.7, 0.8, 0.9],
-            ),
-        ),
-    ]
-
-    for query, model in test_cases:
-        # Arrange
-        remote_storage.insert_data(model)
-
-        # Act
-        loader.load(query.criterion_code, query.sample_size)
-
-        # Assert
-        local_data = local_storage.get_data_for_cv(query)
-        assert local_data is not None
-        assert local_data.criterion_code == model.criterion_code
-        assert local_data.sample_size == model.sample_size
-        assert np.allclose(
-            local_data.results_statistics, model.results_statistics, rtol=1e-7, atol=0.0
-        )
-
-
-def test_load_with_empty_model_data(loader, sample_query, remote_storage, local_storage):
-    """Test load function with empty model data."""
-    # Arrange
-    empty_model = LimitDistributionModel(
-        experiment_id=1,
-        criterion_code="test_criterion",
-        criterion_parameters=[],
-        sample_size=100,
-        monte_carlo_count=1000,
-        results_statistics=[],
-    )
-    remote_storage.insert_data(empty_model)
-
-    # Act
-    loader.load(sample_query.criterion_code, sample_query.sample_size)
-
-    # Assert
-    local_data = local_storage.get_data_for_cv(sample_query)
-    assert local_data is not None
-    assert local_data.results_statistics == []
-
-
-def test_load_data_already_exists_locally(
-    loader, sample_query, sample_model, remote_storage, local_storage
-):
-    """Test load function when data already exists in local storage."""
-    # Arrange - insert same data into both storages
-    remote_storage.insert_data(sample_model)
-
-    sample_model_local = LimitDistributionModel(
-        experiment_id=1,
-        criterion_code="ks_test",
-        criterion_parameters=[],
-        sample_size=100,
-        monte_carlo_count=1000,
-        results_statistics=[0.1, 0.2],
-    )
-    local_storage.insert_data(sample_model_local)
-
-    # Act
-    loader.load(sample_query.criterion_code, sample_query.sample_size)
-
-    # Assert - verify data still exists and is correct
-    local_data = local_storage.get_data_for_cv(sample_query)
-    assert local_data is not None
-    assert np.allclose(
-        local_data.results_statistics, sample_model.results_statistics, rtol=1e-7, atol=0.0
-    )
-
-
-def test_load_multiple_criteria_same_sample_size(loader, remote_storage, local_storage):
-    """Test load function with multiple criteria but same sample size."""
-    # Arrange
-    models = [
-        LimitDistributionModel(
-            experiment_id=1,
-            criterion_code="ks_test",
-            criterion_parameters=[],
-            sample_size=100,
-            monte_carlo_count=1000,
-            results_statistics=[0.1, 0.2],
-        ),
-        LimitDistributionModel(
-            experiment_id=2,
-            criterion_code="ad_test",
-            criterion_parameters=[],
-            sample_size=100,
-            monte_carlo_count=1000,
-            results_statistics=[0.3, 0.4],
-        ),
-    ]
-
-    for model in models:
-        remote_storage.insert_data(model)
-
-    # Act - load each criterion
-    for model in models:
-        query = CriticalValueQuery(
-            criterion_code=model.criterion_code, sample_size=model.sample_size
-        )
-        loader.load(query.criterion_code, query.sample_size)
-
-    # Assert - verify all data was loaded correctly
-    for model in models:
-        query = CriticalValueQuery(
-            criterion_code=model.criterion_code, sample_size=model.sample_size
-        )
-        local_data = local_storage.get_data_for_cv(query)
-        assert local_data is not None
-        assert local_data.criterion_code == model.criterion_code
-        assert np.allclose(
-            local_data.results_statistics, model.results_statistics, rtol=1e-7, atol=0.0
-        )
-
-
-def test_loader_with_unavailable_remote_storage(local_storage, sample_query):
-    """
-    Check that the loader is created correctly, even if
-    the remote database returned None (was unavailable).
-    """
-    loader = CriticalValueLoader(local_storage, None)
-    result = loader.load(sample_query.criterion_code, sample_query.sample_size)
-
-    assert result is False
-
-
-def test_alchemy_storage_create_safe_on_failure():
-    """
-    Checking the create_safe method itself on an invalid URL.
-    """
-    bad_url = "postgresql://non_existent_user:pass@localhost:9999/nothing"
-    storage = AlchemyLimitDistributionStorage.create_safe(bad_url, label="Broken DB")
-
-    assert storage is None
-
-
 def test_load_bulk_all_new_data(loader, local_storage, remote_storage):
     """
-    Test the load_bulk method when all requested criteria are missing from local storage and found in remote storage.
+    Test that load_bulk insert all new data to local storage.
     """
-    # Arrange
     criterion_codes = ["ks", "ad"]
     sample_size = 100
+
+    # Prepare remote data
     models = [
-        LimitDistributionModel(1, "ks", [], sample_size, 1000, [0.1]),
-        LimitDistributionModel(2, "ad", [], sample_size, 1000, [0.2]),
+        LimitDistributionModel(1, "ks", [], sample_size, 1000, [0.1, 0.2]),
+        LimitDistributionModel(2, "ad", [], sample_size, 1000, [0.3, 0.4]),
     ]
     for model in models:
         remote_storage.insert_data(model)
@@ -295,9 +54,9 @@ def test_load_bulk_all_new_data(loader, local_storage, remote_storage):
     result = loader.load_bulk(criterion_codes, sample_size)
 
     # Assert
-    assert result.requested_count == len(criterion_codes)
+    assert result.requested_count == 2
     assert result.already_cached_count == 0
-    assert result.newly_cached_count == len(criterion_codes)
+    assert result.newly_cached_count == 2
     assert result.not_found_codes == []
 
     for model in models:
@@ -306,61 +65,115 @@ def test_load_bulk_all_new_data(loader, local_storage, remote_storage):
         )
         local_data = local_storage.get_data_for_cv(query)
         assert local_data is not None
-        assert np.allclose(
-            local_data.results_statistics, model.results_statistics, rtol=1e-7, atol=0.0
-        )
+        assert np.allclose(local_data.results_statistics, model.results_statistics, rtol=1e-7)
 
 
-def test_load_bulk_with_partial_cache(loader, local_storage, remote_storage):
+def test_load_bulk_partial_cache(loader, local_storage, remote_storage):
     """
     Test the load_bulk method when some criteria are already in local storage and some are missing.
     """
-    # Arrange
-    criterion_codes = ["ks", "ad"]
+    criterion_codes = ["ks", "ad", "cvm"]
     sample_size = 100
 
-    local_model_ks = LimitDistributionModel(1, "ks", [], sample_size, 1000, [0.1])
-    local_storage.insert_data(local_model_ks)
-
-    remote_model_ad = LimitDistributionModel(2, "ad", [], sample_size, 1000, [0.2])
-    remote_storage.insert_data(remote_model_ad)
+    local_storage.insert_data(LimitDistributionModel(1, "ks", [], sample_size, 1000, [0.1]))
+    remote_storage.insert_data(LimitDistributionModel(2, "ad", [], sample_size, 1000, [0.2]))
 
     # Act
     result = loader.load_bulk(criterion_codes, sample_size)
 
     # Assert
-    assert result.requested_count == len(criterion_codes)
-    assert result.already_cached_count == 1
-    assert result.newly_cached_count == 1
-    assert result.not_found_codes == []
+    assert result.requested_count == 3
+    assert result.already_cached_count == 1  # 'ks'
+    assert result.newly_cached_count == 1  # 'ad'
+    assert result.not_found_codes == ["cvm"]
 
-    query_ad = CriticalValueQuery(criterion_code="ad", sample_size=sample_size)
-    local_data_ad = local_storage.get_data_for_cv(query_ad)
-    assert local_data_ad is not None
-    assert np.allclose(
-        local_data_ad.results_statistics,
-        remote_model_ad.results_statistics,
-    )
+    assert local_storage.get_data_for_cv(CriticalValueQuery("ks", sample_size)) is not None
+    assert local_storage.get_data_for_cv(CriticalValueQuery("ad", sample_size)) is not None
+    assert local_storage.get_data_for_cv(CriticalValueQuery("cvm", sample_size)) is None
 
 
-def test_load_bulk_remote_not_found(loader, local_storage, remote_storage):
+def test_load_bulk_empty_remote(loader, local_storage, remote_storage):
     """
-    Test the load_bulk method when none of the requested criteria are found in remote and local storages.
+    Check that load_bulk do not add data to local storage when remote is empty.
     """
-    # Arrange
-    criterion_codes = ["code1", "code2"]
+    criterion_codes = ["missing_1", "missing_2"]
     sample_size = 100
 
     # Act
     result = loader.load_bulk(criterion_codes, sample_size)
 
-    # Assert
-    assert result.requested_count == len(criterion_codes)
+    # Assert Counters
+    assert result.requested_count == 2
     assert result.already_cached_count == 0
     assert result.newly_cached_count == 0
     assert sorted(result.not_found_codes) == sorted(criterion_codes)
 
     for code in criterion_codes:
-        query = CriticalValueQuery(criterion_code=code, sample_size=sample_size)
-        local_data = local_storage.get_data_for_cv(query)
-        assert local_data is None
+        assert local_storage.get_data_for_cv(CriticalValueQuery(code, sample_size)) is None
+
+
+def test_load_bulk_all_cached(loader, local_storage, remote_storage):
+    """
+    Test load_bulk when all requested criteria are already in local cache.
+    """
+    criterion_codes = ["ks", "ad"]
+    sample_size = 100
+
+    for code in criterion_codes:
+        local_storage.insert_data(LimitDistributionModel(1, code, [], sample_size, 1000, [0.5]))
+
+    # Act
+    result = loader.load_bulk(criterion_codes, sample_size)
+
+    # Assert Counters
+    assert result.requested_count == 2
+    assert result.already_cached_count == 2
+    assert result.newly_cached_count == 0
+    assert result.not_found_codes == []
+
+
+def test_load_bulk_with_unavailable_remote(local_storage, sample_size=100):
+    """
+    Test load_bulk when remote storage is None (unavailable).
+    """
+    criterion_codes = ["ks", "ad"]
+    loader = CriticalValueLoader(local_storage, remote_storage=None)
+
+    # Act
+    result = loader.load_bulk(criterion_codes, sample_size)
+
+    # Assert
+    assert result.requested_count == 2
+    assert result.already_cached_count == 0
+    assert result.newly_cached_count == 0
+    assert sorted(result.not_found_codes) == sorted(criterion_codes)
+
+
+def test_load_bulk_preserves_best_monte_carlo(loader, local_storage, remote_storage):
+    """
+    In this test get_bulk_data should return the one with the highest MC count, and it gets cached.
+    """
+    criterion_codes = ["ks"]
+    sample_size = 100
+
+    # Insert data
+    remote_storage.insert_data(LimitDistributionModel(1, "ks", [], sample_size, 500, [0.1]))
+    remote_storage.insert_data(LimitDistributionModel(2, "ks", [], sample_size, 2000, [0.9]))
+
+    # Act
+    loader.load_bulk(criterion_codes, sample_size)
+
+    # Assert
+    local_data = local_storage.get_data_for_cv(CriticalValueQuery("ks", sample_size))
+    assert local_data is not None
+    assert local_data.monte_carlo_count == 2000
+    assert np.allclose(local_data.results_statistics, [0.9])
+
+
+def test_alchemy_storage_create_safe_on_failure():
+    """
+    Verify that create_safe returns None instead of raising on invalid URL.
+    """
+    bad_url = "postgresql://non_existent_user:pass@localhost:9999/nothing"
+    storage = AlchemyLimitDistributionStorage.create_safe(bad_url, label="Broken DB")
+    assert storage is None

--- a/tests/critical_value/test_remote_loader.py
+++ b/tests/critical_value/test_remote_loader.py
@@ -83,8 +83,8 @@ def test_load_bulk_partial_cache(loader, local_storage, remote_storage):
 
     # Assert
     assert result.requested_count == 3
-    assert result.already_cached_count == 1  # 'ks'
-    assert result.newly_cached_count == 1  # 'ad'
+    assert result.already_cached_count == 1
+    assert result.newly_cached_count == 1
     assert result.not_found_codes == ["cvm"]
 
     assert local_storage.get_data_for_cv(CriticalValueQuery("ks", sample_size)) is not None
@@ -125,7 +125,7 @@ def test_load_bulk_all_cached(loader, local_storage, remote_storage):
     # Act
     result = loader.load_bulk(criterion_codes, sample_size)
 
-    # Assert Counters
+    # Assert
     assert result.requested_count == 2
     assert result.already_cached_count == 2
     assert result.newly_cached_count == 0

--- a/tests/critical_value/test_remote_loader.py
+++ b/tests/critical_value/test_remote_loader.py
@@ -276,6 +276,7 @@ def test_alchemy_storage_create_safe_on_failure():
 
     assert storage is None
 
+
 def test_load_bulk_all_new_data(loader, local_storage, remote_storage):
     """
     Test the load_bulk method when all requested criteria are missing from local storage and found in remote storage.

--- a/tests/persistence/limit_distribution/limit_distribution_test.py
+++ b/tests/persistence/limit_distribution/limit_distribution_test.py
@@ -138,3 +138,35 @@ def test_get_data_for_cv(storage, model_factory, query_factory):
 def test_get_data_for_cv_not_found(storage):
     query = CriticalValueQuery(criterion_code="missing", sample_size=999)
     assert storage.get_data_for_cv(query) is None, "Find mystic data"
+
+
+def test_insert_bulk_data(storage, model_factory):
+    models = [
+        model_factory(criterion_code="A", sample_size=100),
+        model_factory(criterion_code="B", sample_size=100),
+    ]
+    storage.insert_bulk_data(models)
+
+    results = storage.get_bulk_data(["A", "B"], 100)
+    assert len(results) == 2
+    assert {r.criterion_code for r in results} == {"A", "B"}
+
+
+def test_get_bulk_data_filtering_best_monte_carlo(storage, model_factory):
+    storage.insert_data(model_factory(criterion_code="A", monte_carlo_count=100))
+    storage.insert_data(model_factory(criterion_code="A", monte_carlo_count=1000))
+
+    results = storage.get_bulk_data(["A"], 100)
+
+    assert len(results) == 1
+    assert results[0].monte_carlo_count == 1000
+
+
+def test_storage_data_mapping_consistency(storage, model_factory):
+    original_model = model_factory(criterion_code="test", monte_carlo_count=500)
+    storage.insert_data(original_model)
+
+    retrieved = storage.get_bulk_data(["test"], 100)[0]
+
+    assert retrieved.criterion_code == original_model.criterion_code
+    assert retrieved.monte_carlo_count == original_model.monte_carlo_count


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant?
-->
## Summary

Implement bulk loading for critical values that minimizes remote database queries by filtering locally cached items and performing batch inserts for missing data.

Solve the issue: #78 

## Quick changelog

- Added `load_bulk method` to **CriticalValueLoader**
- Updated **CompositeCriticalValueResolver** to utilize bulk loading strategy instead of single-item loops
- Implemented `get_bulk_data` and `insert_bulk_data` methods in **AlchemyLimitDistributionStorage**
- Added unit tests for bulk loading

## What's new?

This PR introduces a Bulk Loading Pattern for retrieving critical values, significantly improving performance when running multiple statistical tests at the same time.