### PR TITLE
Update license references 

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ poetry run pre-commit run --all-files --color always --verbose --show-diff-on-fa
 
 ## License
 
-This project is licensed under the terms of the **Apache License Version 2.0**. See the [LICENSE](LICENSE) for more information.
+This project is licensed under the terms of the **Apache-2.0** license. See the [LICENSE](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ poetry run pre-commit run --all-files --color always --verbose --show-diff-on-fa
 
 ## License
 
-This project is licensed under the terms of the **MIT** license. See the [LICENSE](LICENSE) for more information.
+This project is licensed under the terms of the **Apache License Version 2.0**. See the [LICENSE](LICENSE) for more information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Package with statistic criteria for PySATL"
 authors = [
     {name = "PySATL Team", email = "pysatl@yahoo.com"},
 ]
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant?
-->
## Summary

Fixed a license error in `README.md` and `pyproject.toml` to display the Apache 2.0 project license correctly.

## Quick changelog

- Updated `README.md` to state "Apache License 2.0" instead of the incorrect "MIT License".
- Ensured public documentation matches the actual `LICENSE` file and `pyproject.toml` metadata.