### PR TITLE
feat: add Laplace goodness-of-fit statistics

### DIFF
--- a/src/pysatl_criterion/statistics/goodness_of_fit/__init__.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/__init__.py
@@ -92,7 +92,10 @@ from pysatl_criterion.statistics.goodness_of_fit.laplace import (
     AbstractLaplaceGofStatistic,
     AndersonDarlingLaplaceGofStatistic,
     CramerVonMisesLaplaceGofStatistic,
+    GreenwoodLaplaceGofStatistic,
     KolmogorovSmirnovLaplaceGofStatistic,
+    KuiperLaplaceGofStatistic,
+    WatsonLaplaceGofStatistic,
 )
 from pysatl_criterion.statistics.goodness_of_fit.log_normal import (  # type: ignore[attr-defined]
     AbstractLogNormalGofStatistic,
@@ -341,6 +344,9 @@ __all__ = [
     "AndersonDarlingLaplaceGofStatistic",
     "CramerVonMisesLaplaceGofStatistic",
     "KolmogorovSmirnovLaplaceGofStatistic",
+    "GreenwoodLaplaceGofStatistic",
+    "KuiperLaplaceGofStatistic",
+    "WatsonLaplaceGofStatistic",
     # Log-Normal distribution statistics
     "AbstractLogNormalGofStatistic",
     "AndersonDarlingLogNormalGofStatistic",

--- a/src/pysatl_criterion/statistics/goodness_of_fit/__init__.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/__init__.py
@@ -88,6 +88,12 @@ from pysatl_criterion.statistics.goodness_of_fit.graph_goodness_of_fit import (
     GraphIndependenceNumberTestStatistic,
     GraphMaxDegreeTestStatistic,
 )
+from pysatl_criterion.statistics.goodness_of_fit.laplace import (
+    AbstractLaplaceGofStatistic,
+    AndersonDarlingLaplaceGofStatistic,
+    CramerVonMisesLaplaceGofStatistic,
+    KolmogorovSmirnovLaplaceGofStatistic,
+)
 from pysatl_criterion.statistics.goodness_of_fit.log_normal import (  # type: ignore[attr-defined]
     AbstractLogNormalGofStatistic,
     AndersonDarlingLogNormalGofStatistic,
@@ -330,6 +336,11 @@ __all__ = [
     "MoranGammaGofStatistic",
     "ProbabilityPlotCorrelationGammaGofStatistic",
     "WatsonGammaGofStatistic",
+    # Laplace distribution statistics
+    "AbstractLaplaceGofStatistic",
+    "AndersonDarlingLaplaceGofStatistic",
+    "CramerVonMisesLaplaceGofStatistic",
+    "KolmogorovSmirnovLaplaceGofStatistic",
     # Log-Normal distribution statistics
     "AbstractLogNormalGofStatistic",
     "AndersonDarlingLogNormalGofStatistic",

--- a/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
@@ -18,7 +18,15 @@ from pysatl_criterion.statistics.hypothesis import GoodnessOfFitHypothesis
 
 
 class AbstractLaplaceGofStatistic(AbstractGoodnessOfFitStatistic, ABC):
+    """Abstract base class for Laplace distribution goodness-of-fit statistics."""
+
     def __init__(self, t: float = 0.0, s: float = 1.0):
+        """Initialize a Laplace distribution goodness-of-fit statistic.
+
+        :param t: location parameter.
+        :param s: scale parameter greater than zero.
+        :raises ValueError: if the scale parameter is not positive.
+        """
         if s <= 0:
             raise ValueError("Scale must be positive.")
         self.t = t
@@ -26,20 +34,38 @@ class AbstractLaplaceGofStatistic(AbstractGoodnessOfFitStatistic, ABC):
 
     @override
     def hypothesis(self) -> GoodnessOfFitHypothesis:
+        """Get the goodness-of-fit hypothesis for the Laplace distribution.
+
+        :return: hypothesis containing the location and scale parameters.
+        """
         return GoodnessOfFitHypothesis({"t": self.t, "s": self.s})
 
     @staticmethod
     @override
     def distribution() -> DistributionType:
+        """Get the distribution type.
+
+        :return: Laplace distribution type.
+        """
         return DistributionType.LAPLACE
 
     @staticmethod
     @override
     def code():
+        """Get the code identifier for Laplace distribution statistics.
+
+        :return: string code in format ``LAPLACE_{parent_code}``.
+        """
         return f"LAPLACE_{AbstractGoodnessOfFitStatistic.code()}"
 
 
 class KolmogorovSmirnovLaplaceGofStatistic(AbstractLaplaceGofStatistic, KSStatistic):
+    """Kolmogorov--Smirnov EDF test computed with the Laplace reference CDF.
+
+    Compares the empirical distribution function with the theoretical Laplace
+    distribution function and measures their maximum deviation.
+    """
+
     def __init__(
         self,
         alternative_type: AlternativeType = AlternativeType.TWO_TAILED,
@@ -47,60 +73,119 @@ class KolmogorovSmirnovLaplaceGofStatistic(AbstractLaplaceGofStatistic, KSStatis
         t: float = 0.0,
         s: float = 1.0,
     ):
+        """Initialize a Kolmogorov--Smirnov test for a Laplace distribution.
+
+        :param alternative_type: alternative hypothesis used by the KS test.
+        :param mode: calculation mode used by the Kolmogorov--Smirnov statistic.
+        :param t: location parameter of the reference Laplace distribution.
+        :param s: positive scale parameter of the reference Laplace distribution.
+        :raises ValueError: if the scale parameter is not positive.
+        """
         AbstractLaplaceGofStatistic.__init__(self, t=t, s=s)
         KSStatistic.__init__(self, alternative_type=alternative_type, mode=mode)
 
     @staticmethod
     @override
     def short_code():
+        """Get the short code identifier for this test.
+
+        :return: short code string ``KS``.
+        """
         return "KS"
 
     @staticmethod
     @override
     def code():
+        """Get the unique code identifier for this test.
+
+        :return: string code in format ``KS_LAPLACE_{parent_code}``.
+        """
         short_code = KolmogorovSmirnovLaplaceGofStatistic.short_code()
         return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
 
     @override
     def execute_statistic(self, rvs, **kwargs):
+        """Execute the Kolmogorov--Smirnov statistic for a Laplace distribution.
+
+        :param rvs: observations assumed to follow a Laplace distribution.
+        :return: Kolmogorov--Smirnov D statistic computed with the Laplace CDF.
+        """
         sorted_rvs = np.sort(np.asarray(rvs))
         cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
         return KSStatistic.do_execute_statistic(self, sorted_rvs, cdf_vals)
 
 
 class CramerVonMisesLaplaceGofStatistic(AbstractLaplaceGofStatistic, CrammerVonMisesStatistic):
+    """Cramer--von Mises quadratic EDF test for Laplace samples.
+
+    Measures the integrated squared difference between the empirical and
+    theoretical Laplace cumulative distribution functions.
+    """
+
     @staticmethod
     @override
     def short_code():
+        """Get the short code identifier for this test.
+
+        :return: short code string ``CVM``.
+        """
         return "CVM"
 
     @staticmethod
     @override
     def code():
+        """Get the unique code identifier for this test.
+
+        :return: string code in format ``CVM_LAPLACE_{parent_code}``.
+        """
         short_code = CramerVonMisesLaplaceGofStatistic.short_code()
         return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
 
     @override
     def execute_statistic(self, rvs, **kwargs):
+        """Execute the Cramer--von Mises statistic for a Laplace distribution.
+
+        :param rvs: observations assumed to follow a Laplace distribution.
+        :return: Cramer--von Mises W^2 statistic computed with the Laplace CDF.
+        """
         sorted_rvs = np.sort(np.asarray(rvs))
         cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
         return CrammerVonMisesStatistic.do_execute_statistic(self, sorted_rvs, cdf_vals)
 
 
 class AndersonDarlingLaplaceGofStatistic(AbstractLaplaceGofStatistic, ADStatistic):
+    """Anderson--Darling EDF statistic for the Laplace distribution.
+
+    Weights deviations in the distribution tails more heavily than the
+    Kolmogorov--Smirnov and Cramer--von Mises statistics.
+    """
+
     @staticmethod
     @override
     def short_code():
+        """Get the short code identifier for this test.
+
+        :return: short code string ``AD``.
+        """
         return "AD"
 
     @staticmethod
     @override
     def code():
+        """Get the unique code identifier for this test.
+
+        :return: string code in format ``AD_LAPLACE_{parent_code}``.
+        """
         short_code = AndersonDarlingLaplaceGofStatistic.short_code()
         return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
 
     @override
     def execute_statistic(self, rvs, **kwargs):
+        """Execute the Anderson--Darling statistic for a Laplace distribution.
+
+        :param rvs: observations assumed to follow a Laplace distribution.
+        :return: Anderson--Darling A^2 statistic computed from log-CDF values.
+        """
         sorted_rvs = np.sort(np.asarray(rvs))
         log_cdf = scipy_stats.laplace.logcdf(sorted_rvs, loc=self.t, scale=self.s)
         log_sf = scipy_stats.laplace.logsf(sorted_rvs, loc=self.t, scale=self.s)

--- a/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
@@ -8,7 +8,7 @@ from typing_extensions import override
 
 from pysatl_criterion import DistributionType
 from pysatl_criterion.statistics import AbstractGoodnessOfFitStatistic
-from pysatl_criterion.statistics.alternative import AlternativeType
+from pysatl_criterion.statistics.alternative import Alternative, AlternativeType, RightAlternative
 from pysatl_criterion.statistics.goodness_of_fit.common import (
     ADStatistic,
     CrammerVonMisesStatistic,
@@ -190,3 +190,178 @@ class AndersonDarlingLaplaceGofStatistic(AbstractLaplaceGofStatistic, ADStatisti
         log_cdf = scipy_stats.laplace.logcdf(sorted_rvs, loc=self.t, scale=self.s)
         log_sf = scipy_stats.laplace.logsf(sorted_rvs, loc=self.t, scale=self.s)
         return ADStatistic.do_execute_statistic(self, sorted_rvs, log_cdf=log_cdf, log_sf=log_sf)
+
+
+class KuiperLaplaceGofStatistic(AbstractLaplaceGofStatistic):
+    """
+    Kuiper EDF statistic for the Laplace distribution.
+
+    Sums the maximum positive and negative deviations between the empirical
+    distribution function and the theoretical Laplace distribution function.
+    """
+
+    @override
+    def alternative(self) -> Alternative:
+        return RightAlternative()
+
+    @staticmethod
+    @override
+    def short_code():
+        """
+        Get the short code identifier for this test.
+
+        :return: short code string ``KUI``.
+        """
+        return "KUI"
+
+    @staticmethod
+    @override
+    def code():
+        """
+        Get the unique code identifier for this test.
+
+        :return: string code in format ``KUI_LAPLACE_{parent_code}``.
+        """
+        short_code = KuiperLaplaceGofStatistic.short_code()
+        return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs):
+        """
+        Execute the Kuiper statistic for a Laplace distribution.
+        :param rvs: observations assumed to follow a Laplace distribution.
+        :return: Kuiper statistic ``V = D+ + D-`` computed with the Laplace CDF.
+        :raises ValueError: if the sample is empty.
+        """
+
+        sorted_rvs = np.sort(np.asarray(rvs))
+        n = len(sorted_rvs)
+
+        if n == 0:
+            raise ValueError(
+                "At least one observation is required to compute the Kuiper statistic."
+            )
+
+        cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
+
+        i = np.arange(1, n + 1)
+        d_plus = np.max(i / n - cdf_vals)
+        d_minus = np.max(cdf_vals - (i - 1) / n)
+
+        return float(d_plus + d_minus)
+
+
+class WatsonLaplaceGofStatistic(AbstractLaplaceGofStatistic):
+    """Watson EDF statistic for the Laplace distribution.
+
+    Computes a centered modification of the Cramer--von Mises statistic
+    by removing the squared mean deviation of the transformed observations.
+    """
+
+    @override
+    def alternative(self) -> Alternative:
+        return RightAlternative()
+
+    @staticmethod
+    @override
+    def short_code():
+        """
+        Get short code identifier for this test.
+
+        :return: short code string "WAT".
+        """
+        return "WAT"
+
+    @staticmethod
+    @override
+    def code():
+        """
+        Get unique code identifier for this test.
+
+        :return: string code in format "WAT_LAPLACE_{parent_code}".
+        """
+        short_code = WatsonLaplaceGofStatistic.short_code()
+        return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs):
+        """
+        Execute the Watson test statistic for Laplace distribution.
+
+        :param rvs: array of observations assumed to follow Laplace(location, scale).
+        :return: Watson U^2 statistic derived from the Laplace CDF values.
+        :raises ValueError: if sample is empty.
+        """
+
+        sorted_rvs = np.sort(np.asarray(rvs))
+        n = len(sorted_rvs)
+        if n == 0:
+            raise ValueError(
+                "At least one observation is required to compute the Watson statistic."
+            )
+
+        cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
+        u = (2 * np.arange(1, n + 1) - 1) / (2 * n)
+        diff = cdf_vals - u
+        w_squared = 1.0 / (12 * n) + np.sum(diff**2)
+        mean_adj = np.sum(cdf_vals) - n / 2
+        return float(w_squared - (mean_adj**2) / n)
+
+
+class GreenwoodLaplaceGofStatistic(AbstractLaplaceGofStatistic):
+    """Greenwood spacing statistic for the Laplace distribution.
+
+    Computes the sum of squared spacings between consecutive values of the
+    Laplace cumulative distribution function. Large values indicate clustering
+    or uneven spacing in the probability-transformed sample.
+    """
+
+    @override
+    def alternative(self) -> Alternative:
+        """Return the right-tailed alternative for the Greenwood statistic.
+
+        :return: right-tailed alternative.
+        """
+        return RightAlternative()
+
+    @staticmethod
+    @override
+    def short_code():
+        """Get the short code identifier for this test.
+
+        :return: short code string ``GRW``.
+        """
+        return "GRW"
+
+    @staticmethod
+    @override
+    def code():
+        """Get the unique code identifier for this test.
+
+        :return: string code in format ``GRW_LAPLACE_{parent_code}``.
+        """
+        short_code = GreenwoodLaplaceGofStatistic.short_code()
+        return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        """Execute the Greenwood spacing statistic for a Laplace distribution.
+
+        :param rvs: observations assumed to follow a Laplace distribution.
+        :return: Greenwood statistic computed from the spacings of the Laplace CDF.
+        :raises ValueError: if the sample is empty.
+        """
+        sorted_rvs = np.sort(np.asarray(rvs))
+        n = len(sorted_rvs)
+        if n == 0:
+            raise ValueError(
+                "At least one observation is required to compute the Greenwood statistic."
+            )
+
+        cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
+        spacings = np.diff(np.concatenate(([0.0], cdf_vals, [1.0])))
+
+        if np.any(spacings < 0):
+            raise ValueError("Spacings must be non-negative; check input data ordering.")
+
+        return float(np.sum(spacings**2))

--- a/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from abc import ABC
+
+import numpy as np
+import scipy.stats as scipy_stats
+from typing_extensions import override
+
+from pysatl_criterion import DistributionType
+from pysatl_criterion.statistics import AbstractGoodnessOfFitStatistic
+from pysatl_criterion.statistics.alternative import AlternativeType
+from pysatl_criterion.statistics.goodness_of_fit.common import (
+    ADStatistic,
+    CrammerVonMisesStatistic,
+    KSStatistic,
+)
+from pysatl_criterion.statistics.hypothesis import GoodnessOfFitHypothesis
+
+
+class AbstractLaplaceGofStatistic(AbstractGoodnessOfFitStatistic, ABC):
+    def __init__(self, t: float = 0.0, s: float = 1.0):
+        if s <= 0:
+            raise ValueError("Scale must be positive.")
+        self.t = t
+        self.s = s
+
+    @override
+    def hypothesis(self) -> GoodnessOfFitHypothesis:
+        return GoodnessOfFitHypothesis({"t": self.t, "s": self.s})
+
+    @staticmethod
+    @override
+    def distribution() -> DistributionType:
+        return DistributionType.LAPLACE
+
+    @staticmethod
+    @override
+    def code():
+        return f"LAPLACE_{AbstractGoodnessOfFitStatistic.code()}"
+
+
+class KolmogorovSmirnovLaplaceGofStatistic(AbstractLaplaceGofStatistic, KSStatistic):
+    def __init__(
+        self,
+        alternative_type: AlternativeType = AlternativeType.TWO_TAILED,
+        mode="auto",
+        t: float = 0.0,
+        s: float = 1.0,
+    ):
+        AbstractLaplaceGofStatistic.__init__(self, t=t, s=s)
+        KSStatistic.__init__(self, alternative_type=alternative_type, mode=mode)
+
+    @staticmethod
+    @override
+    def short_code():
+        return "KS"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = KolmogorovSmirnovLaplaceGofStatistic.short_code()
+        return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        sorted_rvs = np.sort(np.asarray(rvs))
+        cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
+        return KSStatistic.do_execute_statistic(self, sorted_rvs, cdf_vals)
+
+
+class CramerVonMisesLaplaceGofStatistic(AbstractLaplaceGofStatistic, CrammerVonMisesStatistic):
+    @staticmethod
+    @override
+    def short_code():
+        return "CVM"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = CramerVonMisesLaplaceGofStatistic.short_code()
+        return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        sorted_rvs = np.sort(np.asarray(rvs))
+        cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
+        return CrammerVonMisesStatistic.do_execute_statistic(self, sorted_rvs, cdf_vals)
+
+
+class AndersonDarlingLaplaceGofStatistic(AbstractLaplaceGofStatistic, ADStatistic):
+    @staticmethod
+    @override
+    def short_code():
+        return "AD"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = AndersonDarlingLaplaceGofStatistic.short_code()
+        return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        sorted_rvs = np.sort(np.asarray(rvs))
+        log_cdf = scipy_stats.laplace.logcdf(sorted_rvs, loc=self.t, scale=self.s)
+        log_sf = scipy_stats.laplace.logsf(sorted_rvs, loc=self.t, scale=self.s)
+        return ADStatistic.do_execute_statistic(self, sorted_rvs, log_cdf=log_cdf, log_sf=log_sf)

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -1,0 +1,100 @@
+import pytest
+
+from pysatl_criterion import DistributionType
+from pysatl_criterion.statistics.goodness_of_fit.laplace import (
+    AbstractLaplaceGofStatistic,
+    AndersonDarlingLaplaceGofStatistic,
+    CramerVonMisesLaplaceGofStatistic,
+    KolmogorovSmirnovLaplaceGofStatistic,
+)
+
+
+_SAMPLE = [0.1, 0.2, 0.3]
+_LOCATION = 0.0
+_SCALE = 1.0
+
+
+def test_laplace_base_code():
+    assert AbstractLaplaceGofStatistic.code() == "LAPLACE_GOODNESS_OF_FIT"
+
+
+def test_laplace_hypothesis():
+    statistic = KolmogorovSmirnovLaplaceGofStatistic(t=_LOCATION, s=_SCALE)
+
+    hypothesis = statistic.hypothesis()
+
+    assert hypothesis.params == {"t": _LOCATION, "s": _SCALE}
+
+
+def test_kolmogorov_smirnov_laplace_statistic():
+    statistic = KolmogorovSmirnovLaplaceGofStatistic(
+        t=_LOCATION,
+        s=_SCALE,
+    )
+
+    result = statistic.execute_statistic(_SAMPLE)
+
+    assert result == pytest.approx(0.5475812909820202)
+
+
+def test_cramer_von_mises_laplace_statistic():
+    statistic = CramerVonMisesLaplaceGofStatistic(
+        t=_LOCATION,
+        s=_SCALE,
+    )
+
+    result = statistic.execute_statistic(_SAMPLE)
+
+    assert result == pytest.approx(0.2225993471193351)
+
+
+def test_anderson_darling_laplace_statistic():
+    statistic = AndersonDarlingLaplaceGofStatistic(
+        t=_LOCATION,
+        s=_SCALE,
+    )
+
+    result = statistic.execute_statistic(_SAMPLE)
+
+    assert result == pytest.approx(1.0445557661164182)
+
+
+@pytest.mark.parametrize(
+    ("statistic_class", "expected_code"),
+    [
+        (
+            KolmogorovSmirnovLaplaceGofStatistic,
+            "KS_LAPLACE_GOODNESS_OF_FIT",
+        ),
+        (
+            CramerVonMisesLaplaceGofStatistic,
+            "CVM_LAPLACE_GOODNESS_OF_FIT",
+        ),
+        (
+            AndersonDarlingLaplaceGofStatistic,
+            "AD_LAPLACE_GOODNESS_OF_FIT",
+        ),
+    ],
+)
+def test_laplace_statistic_codes(statistic_class, expected_code):
+    assert statistic_class.code() == expected_code
+
+
+def test_laplace_distribution_type():
+    assert AbstractLaplaceGofStatistic.distribution() == DistributionType.LAPLACE
+
+
+@pytest.mark.parametrize("scale", [0.0, -1.0])
+def test_laplace_positive_scale_required(scale):
+    with pytest.raises(ValueError, match="Scale must be positive."):
+        KolmogorovSmirnovLaplaceGofStatistic(s=scale)
+
+
+def test_laplace_parameters_affect_statistic():
+    default_statistic = KolmogorovSmirnovLaplaceGofStatistic(t=0.0, s=1.0)
+    shifted_statistic = KolmogorovSmirnovLaplaceGofStatistic(t=1.0, s=2.0)
+
+    default_result = default_statistic.execute_statistic(_SAMPLE)
+    shifted_result = shifted_statistic.execute_statistic(_SAMPLE)
+
+    assert default_result != pytest.approx(shifted_result)

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -5,7 +5,10 @@ from pysatl_criterion.statistics.goodness_of_fit.laplace import (
     AbstractLaplaceGofStatistic,
     AndersonDarlingLaplaceGofStatistic,
     CramerVonMisesLaplaceGofStatistic,
+    GreenwoodLaplaceGofStatistic,
     KolmogorovSmirnovLaplaceGofStatistic,
+    KuiperLaplaceGofStatistic,
+    WatsonLaplaceGofStatistic,
 )
 
 
@@ -107,6 +110,9 @@ def test_anderson_darling_laplace_statistic():
         (KolmogorovSmirnovLaplaceGofStatistic, 0.10023112481762697),
         (CramerVonMisesLaplaceGofStatistic, 0.06360683737580435),
         (AndersonDarlingLaplaceGofStatistic, 0.4993990825244552),
+        (GreenwoodLaplaceGofStatistic, 0.03654367524062204),
+        (KuiperLaplaceGofStatistic, 0.16712891630192053),
+        (WatsonLaplaceGofStatistic, 0.05656030222478137),
     ],
 )
 def test_laplace_statistics_on_large_sample(statistic_class, expected_value):
@@ -133,6 +139,18 @@ def test_laplace_statistics_on_large_sample(statistic_class, expected_value):
         (
             AndersonDarlingLaplaceGofStatistic,
             "AD_LAPLACE_GOODNESS_OF_FIT",
+        ),
+        (
+            GreenwoodLaplaceGofStatistic,
+            "GRW_LAPLACE_GOODNESS_OF_FIT",
+        ),
+        (
+            KuiperLaplaceGofStatistic,
+            "KUI_LAPLACE_GOODNESS_OF_FIT",
+        ),
+        (
+            WatsonLaplaceGofStatistic,
+            "WAT_LAPLACE_GOODNESS_OF_FIT",
         ),
     ],
 )
@@ -166,3 +184,18 @@ def test_laplace_parameters_affect_statistic():
     shifted_result = shifted_statistic.execute_statistic(_SAMPLE)
 
     assert default_result != pytest.approx(shifted_result)
+
+
+@pytest.mark.parametrize(
+    "statistic_class",
+    [
+        KuiperLaplaceGofStatistic,
+        WatsonLaplaceGofStatistic,
+        GreenwoodLaplaceGofStatistic,
+    ],
+)
+def test_additional_laplace_statistics_require_non_empty_sample(statistic_class):
+    """Additional Laplace statistics should reject an empty sample."""
+
+    with pytest.raises(ValueError, match="At least one observation is required"):
+        statistic_class(t=_LOCATION, s=_SCALE).execute_statistic([])

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -10,6 +10,38 @@ from pysatl_criterion.statistics.goodness_of_fit.laplace import (
 
 
 _SAMPLE = [0.1, 0.2, 0.3]
+_LARGE_SAMPLE = [
+    -3.2,
+    -2.7,
+    -2.1,
+    -1.8,
+    -1.5,
+    -1.3,
+    -1.1,
+    -0.9,
+    -0.7,
+    -0.5,
+    -0.4,
+    -0.3,
+    -0.2,
+    -0.1,
+    0.0,
+    0.1,
+    0.2,
+    0.3,
+    0.4,
+    0.5,
+    0.7,
+    0.9,
+    1.1,
+    1.3,
+    1.5,
+    1.8,
+    2.1,
+    2.4,
+    2.8,
+    3.3,
+]
 _LOCATION = 0.0
 _SCALE = 1.0
 
@@ -57,6 +89,22 @@ def test_anderson_darling_laplace_statistic():
     result = statistic.execute_statistic(_SAMPLE)
 
     assert result == pytest.approx(1.0445557661164182)
+
+
+@pytest.mark.parametrize(
+    ("statistic_class", "expected_value"),
+    [
+        (KolmogorovSmirnovLaplaceGofStatistic, 0.10023112481762697),
+        (CramerVonMisesLaplaceGofStatistic, 0.06360683737580435),
+        (AndersonDarlingLaplaceGofStatistic, 0.4993990825244552),
+    ],
+)
+def test_laplace_statistics_on_large_sample(statistic_class, expected_value):
+    statistic = statistic_class(t=_LOCATION, s=_SCALE)
+
+    result = statistic.execute_statistic(_LARGE_SAMPLE)
+
+    assert result == pytest.approx(expected_value)
 
 
 @pytest.mark.parametrize(

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -47,10 +47,14 @@ _SCALE = 1.0
 
 
 def test_laplace_base_code():
+    """Ensure Laplace GOF statistics expose the expected code identifier."""
+
     assert AbstractLaplaceGofStatistic.code() == "LAPLACE_GOODNESS_OF_FIT"
 
 
 def test_laplace_hypothesis():
+    """Ensure the Laplace location and scale are stored in the hypothesis."""
+
     statistic = KolmogorovSmirnovLaplaceGofStatistic(t=_LOCATION, s=_SCALE)
 
     hypothesis = statistic.hypothesis()
@@ -59,6 +63,8 @@ def test_laplace_hypothesis():
 
 
 def test_kolmogorov_smirnov_laplace_statistic():
+    """Verify the Kolmogorov--Smirnov statistic for a Laplace sample."""
+
     statistic = KolmogorovSmirnovLaplaceGofStatistic(
         t=_LOCATION,
         s=_SCALE,
@@ -70,6 +76,8 @@ def test_kolmogorov_smirnov_laplace_statistic():
 
 
 def test_cramer_von_mises_laplace_statistic():
+    """Verify the Cramer--von Mises statistic for a Laplace sample."""
+
     statistic = CramerVonMisesLaplaceGofStatistic(
         t=_LOCATION,
         s=_SCALE,
@@ -81,6 +89,8 @@ def test_cramer_von_mises_laplace_statistic():
 
 
 def test_anderson_darling_laplace_statistic():
+    """Verify the Anderson--Darling statistic for a Laplace sample."""
+
     statistic = AndersonDarlingLaplaceGofStatistic(
         t=_LOCATION,
         s=_SCALE,
@@ -100,6 +110,8 @@ def test_anderson_darling_laplace_statistic():
     ],
 )
 def test_laplace_statistics_on_large_sample(statistic_class, expected_value):
+    """Check all Laplace EDF statistics against a larger reference sample."""
+
     statistic = statistic_class(t=_LOCATION, s=_SCALE)
 
     result = statistic.execute_statistic(_LARGE_SAMPLE)
@@ -125,20 +137,28 @@ def test_laplace_statistics_on_large_sample(statistic_class, expected_value):
     ],
 )
 def test_laplace_statistic_codes(statistic_class, expected_code):
+    """Ensure every Laplace statistic exposes a stable code identifier."""
+
     assert statistic_class.code() == expected_code
 
 
 def test_laplace_distribution_type():
+    """Ensure Laplace statistics report the Laplace distribution type."""
+
     assert AbstractLaplaceGofStatistic.distribution() == DistributionType.LAPLACE
 
 
 @pytest.mark.parametrize("scale", [0.0, -1.0])
 def test_laplace_positive_scale_required(scale):
+    """Laplace statistic constructors should reject non-positive scales."""
+
     with pytest.raises(ValueError, match="Scale must be positive."):
         KolmogorovSmirnovLaplaceGofStatistic(s=scale)
 
 
 def test_laplace_parameters_affect_statistic():
+    """Changing location and scale should change the resulting KS statistic."""
+
     default_statistic = KolmogorovSmirnovLaplaceGofStatistic(t=0.0, s=1.0)
     shifted_statistic = KolmogorovSmirnovLaplaceGofStatistic(t=1.0, s=2.0)
 


### PR DESCRIPTION
## Summary

Implemented Laplace goodness-of-fit statistics:

- AbstractLaplaceGofStatistic
- KolmogorovSmirnovLaplaceGofStatistic
- CramerVonMisesLaplaceGofStatistic
- AndersonDarlingLaplaceGofStatistic
- KuiperLaplaceGofStatistic
- WatsonLaplaceGofStatistic
- GreenwoodLaplaceGofStatistic

Added unit tests and documentation for all implemented statistics.

## Checks

- `poetry run pytest`
- `poetry run pre-commit run --all-files --color always --verbose --show-diff-on-failure`