### PR TITLE
Add get_available_criteria

### DIFF
--- a/src/pysatl_criterion/utils/statistic.py
+++ b/src/pysatl_criterion/utils/statistic.py
@@ -1,30 +1,54 @@
 import inspect
+from importlib import import_module
 from typing import Any
 
 from pysatl_criterion import DistributionType
 from pysatl_criterion.statistics import AbstractGoodnessOfFitStatistic
 
 
-def get_available_criteria(distribution: DistributionType) -> list[str]:
+def get_available_criteria(
+    distribution: DistributionType,
+) -> list[type[AbstractGoodnessOfFitStatistic]]:
+    """
+    Return a list of all non-abstract statistical criteria available for
+    the given distribution.
+
+    This function inspects all subclasses of AbstractGoodnessOfFitStatistic and filters out
+    abstract classes.
+
+    :param distribution: distribution descriptor to filter available statistical criteria.
+    :return: list of non-abstract subclasses of AbstractGoodnessOfFitStatistic for the
+    requested distribution.
+    """
+    __load_goodness_of_fit_statistics()
+
+    return [
+        cls
+        for cls in __get_all_subclasses(AbstractGoodnessOfFitStatistic)
+        if not inspect.isabstract(cls) and cls.distribution() == distribution
+    ]
+
+
+def get_available_criteria_codes(distribution: DistributionType) -> list[str]:
     """
     Return a list of short codes for all non-abstract statistical criteria available for
     the given distribution.
 
-    This function inspects all direct subclasses of the distribution's base_class and filters out
-    abstract classes.
-    For each concrete subclass, its short_code() method is invoked to obtain
-    a unique short identifier.
+    For each concrete criterion class, its short_code() method is invoked to obtain
+    a short identifier.
 
-    :param distribution: distribution descriptor whose base_class defines the root class for
-    available statistical criteria.
+    :param distribution: distribution descriptor to filter available statistical criteria.
     :return: list of short codes corresponding to all non-abstract subclasses of
-    distribution.base_class.
+    AbstractGoodnessOfFitStatistic for the requested distribution.
     """
-    return [
-        cls.short_code()
-        for cls in __get_all_subclasses(AbstractGoodnessOfFitStatistic)
-        if not inspect.isabstract(cls) and cls.distribution() == distribution
-    ]
+    return [criterion.short_code() for criterion in get_available_criteria(distribution)]
+
+
+def __load_goodness_of_fit_statistics() -> None:
+    """
+    Load goodness-of-fit statistic modules so subclasses are registered in Python runtime.
+    """
+    import_module("pysatl_criterion.statistics.goodness_of_fit")
 
 
 def __get_all_subclasses(cls: type[Any]) -> set[type[AbstractGoodnessOfFitStatistic]]:

--- a/tests/utils/test_statistic.py
+++ b/tests/utils/test_statistic.py
@@ -1,9 +1,11 @@
+import inspect
 from collections import Counter
 
 import pytest
 
 from pysatl_criterion import DistributionType
-from pysatl_criterion.utils.statistic import get_available_criteria
+from pysatl_criterion.statistics import AbstractGoodnessOfFitStatistic
+from pysatl_criterion.utils.statistic import get_available_criteria, get_available_criteria_codes
 
 
 @pytest.mark.parametrize(
@@ -174,5 +176,18 @@ from pysatl_criterion.utils.statistic import get_available_criteria
     ],
 )
 def test_get_available_criteria_all_criteria(distribution, result):
-    criteria = get_available_criteria(DistributionType(distribution))
+    criteria = get_available_criteria_codes(DistributionType(distribution))
     assert Counter(criteria) == Counter(result)
+
+
+@pytest.mark.parametrize(
+    "distribution",
+    ["normal", "exponential", "weibull", "uniform", "student", "gamma"],
+)
+def test_get_available_criteria_all_criteria_classes(distribution):
+    criteria = get_available_criteria(DistributionType(distribution))
+
+    assert criteria
+    assert all(issubclass(criterion, AbstractGoodnessOfFitStatistic) for criterion in criteria)
+    assert all(not inspect.isabstract(criterion) for criterion in criteria)
+    assert all(criterion.distribution() == DistributionType(distribution) for criterion in criteria)


### PR DESCRIPTION
## Summary

Add `get_available_criteria` for returning available goodness-of-fit statistic classes and move short-code lookup to `get_available_criteria_codes`.

## Quick changelog

- Renamed the previous `get_available_criteria` behavior to `get_available_criteria_codes`.
- Added a new `get_available_criteria` method returning concrete `AbstractGoodnessOfFitStatistic` subclasses.
- Added explicit loading of goodness-of-fit statistic modules before subclass discovery.
- Updated statistic utility tests for both class lookup and short-code lookup.

## What's new?

This PR separates two related utility behaviors:

- `get_available_criteria(distribution)` now returns the available non-abstract goodness-of-fit statistic classes for the requested distribution.
- `get_available_criteria_codes(distribution)` preserves the previous behavior and returns the list of statistic short codes.

The implementation also explicitly imports `pysatl_criterion.statistics.goodness_of_fit` before walking `AbstractGoodnessOfFitStatistic.__subclasses__()`, so criteria discovery no longer depends on prior import order.

Validation added in `tests/utils/test_statistic.py` checks that:

- short-code results remain unchanged for supported distributions;
- returned criteria are subclasses of `AbstractGoodnessOfFitStatistic`;
- returned criteria are concrete, non-abstract classes;
- returned criteria match the requested distribution.
```
