### PR TITLE
feat: add Pareto goodness-of-fit statistics 

### DIFF
--- a/src/pysatl_criterion/distribution/distribution_type.py
+++ b/src/pysatl_criterion/distribution/distribution_type.py
@@ -53,6 +53,9 @@ class DistributionType(Enum):
     SCALE_CON_NORMAL = "scale_con_normal"
     TRUNC_NORMAL = "trunc_normal"
     TUKEY = "tukey"
+    FISHER = "fisher"
+    RAYLEIGH = "rayleigh"
+    PARETO = "pareto"
 
     def __new__(cls, value: str):
         """

--- a/src/pysatl_criterion/statistics/goodness_of_fit/pareto.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/pareto.py
@@ -51,7 +51,6 @@ class AbstractParetoGofStatistic(AbstractGoodnessOfFitStatistic, ABC):
 
 
 class KolmogorovSmirnovParetoGofStatistic(AbstractParetoGofStatistic, KSStatistic):
-
     def __init__(
         self,
         alternative_type: AlternativeType = AlternativeType.TWO_TAILED,
@@ -101,7 +100,6 @@ class AndersonDarlingParetoGofStatistic(AbstractParetoGofStatistic, ADStatistic)
 
 
 class CramerVonMisesParetoGofStatistic(AbstractParetoGofStatistic, CrammerVonMisesStatistic):
-
     @staticmethod
     @override
     def short_code():
@@ -119,8 +117,8 @@ class CramerVonMisesParetoGofStatistic(AbstractParetoGofStatistic, CrammerVonMis
         cdf_vals = scipy_stats.pareto.cdf(sorted_rvs, b=self.shape, scale=self.scale)
         return CrammerVonMisesStatistic.do_execute_statistic(self, sorted_rvs, cdf_vals)
 
-class LillieforsParetoGofStatistic(AbstractParetoGofStatistic, LillieforsTest):
 
+class LillieforsParetoGofStatistic(AbstractParetoGofStatistic, LillieforsTest):
     def __init__(self, shape: float = 1.0, scale: float = 1.0):
         AbstractParetoGofStatistic.__init__(self, shape=shape, scale=scale)
 
@@ -141,7 +139,7 @@ class LillieforsParetoGofStatistic(AbstractParetoGofStatistic, LillieforsTest):
         n = sample.size
         if n == 0:
             raise ValueError("At least one observation is required for the Lilliefors statistic.")
-        
+
         if np.any(sample <= 0):
             raise ValueError("Sample values must be strictly positive for Pareto distribution.")
         scale_hat = float(np.min(sample))
@@ -152,7 +150,7 @@ class LillieforsParetoGofStatistic(AbstractParetoGofStatistic, LillieforsTest):
 
         sorted_sample = np.sort(sample)
         cdf_vals = scipy_stats.pareto.cdf(sorted_sample, b=shape_hat, scale=scale_hat)
-        
+
         return super().do_execute_statistic(sorted_sample, cdf_vals)
 
 
@@ -172,20 +170,21 @@ class MinToshiyukiParetoGofStatistic(AbstractParetoGofStatistic, MinToshiyukiSta
     def execute_statistic(self, rvs, **kwargs):
         sorted_rvs = np.sort(np.asarray(rvs, dtype=float))
         cdf_vals = scipy_stats.pareto.cdf(sorted_rvs, b=self.shape, scale=self.scale)
-        
+
         cdf_vals = np.clip(cdf_vals, 1e-15, 1.0 - 1e-15)
-        
+
         return super().do_execute_statistic(cdf_vals)
-    
+
+
 class ObradovicParetoGofStatistic(AbstractParetoGofStatistic):
     """
     Obradovic-Jovanovic-Milosevic U-statistic goodness-of-fit test for Pareto distribution.
-    
-    This statistic is based on a new characterization: X and max(X/Y, Y/X) are identically 
+
+    This statistic is based on a new characterization: X and max(X/Y, Y/X) are identically
     distributed if and only if X follows a Pareto distribution.
-    
+
     References:
-        - Obradovic M., Jovanovic M., Milosevic B. (2014). Goodness of Fit Tests 
+        - Obradovic M., Jovanovic M., Milosevic B. (2014). Goodness of Fit Tests
           for Pareto Distribution Based on a Characterization and their Asymptotics.
           arXiv:1310.5510v2
     """
@@ -205,7 +204,7 @@ class ObradovicParetoGofStatistic(AbstractParetoGofStatistic):
     def execute_statistic(self, rvs, **kwargs):
         """
         Execute the Obradovic et al. integral test statistic (Tn) for Pareto distribution.
-        
+
         :param rvs: array of observations.
         :return: Tn test statistic value.
         """
@@ -213,37 +212,39 @@ class ObradovicParetoGofStatistic(AbstractParetoGofStatistic):
         n = x.size
         if n < 2:
             raise ValueError("At least 2 observations are required for this statistic.")
-            
+
         if np.any(x <= 0):
             raise ValueError("Sample values must be strictly positive.")
 
         N = n * (n - 1) // 2
-        
+
         idx_j, idx_k = np.triu_indices(n, k=1)
         pairs_max = np.maximum(x[idx_j] / x[idx_k], x[idx_k] / x[idx_j])
-        
+
         pooled = np.concatenate([x, pairs_max])
-        
+
         from scipy.stats import rankdata
-        all_ranks = rankdata(pooled, method='average')
-        
+
+        all_ranks = rankdata(pooled, method="average")
+
         r_j = all_ranks[:n]
 
         numerator = 2 * np.sum(r_j) - (n + 1) * (n + N)
         denominator = 2 * n * N
-        
+
         return float(numerator / denominator)
-    
+
+
 class GreenwoodParetoGofStatistic(AbstractParetoGofStatistic):
     """
     Greenwood's goodness-of-fit statistic for the Pareto distribution.
 
     This statistic tests the Pareto assumption by transforming the sample
-    via Y_i = ln(X_i / min(X)) and evaluating Greenwood's statistic on the 
+    via Y_i = ln(X_i / min(X)) and evaluating Greenwood's statistic on the
     resulting exponentially distributed spacing candidates.
 
     References:
-        - Greenwood, M. (1946). The statistical study of infectious diseases. 
+        - Greenwood, M. (1946). The statistical study of infectious diseases.
           Journal of the Royal Statistical Society, 109(2), 85-110.
     """
 
@@ -285,14 +286,15 @@ class GreenwoodParetoGofStatistic(AbstractParetoGofStatistic):
         g = np.sum(y**2) / (sum_y**2)
 
         return float(g)
-    
+
+
 class LequesneKlParetoGofStatistic(AbstractParetoGofStatistic):
     """
     Lequesne's entropy-based goodness-of-fit test for Pareto distribution
     using Kullback-Leibler divergence and Vasicek's entropy estimator.
-    
+
     References:
-        - Lequesne, J. (2013). Entropy-based goodness-of-fit test: Application 
+        - Lequesne, J. (2013). Entropy-based goodness-of-fit test: Application
           to the Pareto distribution. AIP Conference Proceedings, 1553, 155-162.
     """
 
@@ -319,8 +321,7 @@ class LequesneKlParetoGofStatistic(AbstractParetoGofStatistic):
             raise ValueError("Sample values must be strictly positive.")
         beta_hat = n / np.sum(np.log(x / sigma_hat))
 
-
-        m = kwargs.get('m', int(np.floor(np.sqrt(n))))
+        m = kwargs.get("m", int(np.floor(np.sqrt(n))))
         if m < 1 or m >= n // 2:
             m = max(1, n // 4)
 
@@ -337,12 +338,12 @@ class LequesneKlParetoGofStatistic(AbstractParetoGofStatistic):
         for i in range(1, n + 1):
             diff = get_order_stat(i + m) - get_order_stat(i - m)
             if diff <= 0:
-                diff = 1e-10 
+                diff = 1e-10
             vasicek_sum += np.log((n / (2 * m)) * diff)
         v_mn = vasicek_sum / n
 
         mean_log_scaled = np.mean(np.log(x / sigma_hat))
 
-        kl_div = - v_mn - np.log(beta_hat) + np.log(sigma_hat) + (beta_hat + 1) * mean_log_scaled
+        kl_div = -v_mn - np.log(beta_hat) + np.log(sigma_hat) + (beta_hat + 1) * mean_log_scaled
 
         return float(np.abs(kl_div))

--- a/src/pysatl_criterion/statistics/goodness_of_fit/pareto.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/pareto.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from abc import ABC
+
+import numpy as np
+import scipy.stats as scipy_stats
+from typing_extensions import override
+
+from pysatl_criterion import DistributionType
+from pysatl_criterion.statistics import AbstractGoodnessOfFitStatistic
+from pysatl_criterion.statistics.alternative import AlternativeType
+from pysatl_criterion.statistics.goodness_of_fit.common import (
+    ADStatistic,
+    CrammerVonMisesStatistic,
+    KSStatistic,
+    LillieforsTest,
+    MinToshiyukiStatistic,
+)
+from pysatl_criterion.statistics.hypothesis import GoodnessOfFitHypothesis
+
+
+class AbstractParetoGofStatistic(AbstractGoodnessOfFitStatistic, ABC):
+    def __init__(self, shape: float = 1.0, scale: float = 1.0):
+        """
+        Initialize Pareto distribution goodness-of-fit statistic.
+
+        :param shape: shape parameter (shape) > 0.
+        :param scale: scale parameter (scale) > 0.
+        :raises ValueError: if shape or scale is not positive.
+        """
+        if shape <= 0:
+            raise ValueError("Shape must be positive.")
+        if scale <= 0:
+            raise ValueError("Scale must be positive.")
+        self.shape = shape
+        self.scale = scale
+
+    @override
+    def hypothesis(self) -> GoodnessOfFitHypothesis:
+        return GoodnessOfFitHypothesis({"shape": self.shape, "scale": self.scale})
+
+    @staticmethod
+    @override
+    def distribution() -> DistributionType:
+        return DistributionType.PARETO
+
+    @staticmethod
+    @override
+    def code():
+        return f"PARETO_{AbstractGoodnessOfFitStatistic.code()}"
+
+
+class KolmogorovSmirnovParetoGofStatistic(AbstractParetoGofStatistic, KSStatistic):
+
+    def __init__(
+        self,
+        alternative_type: AlternativeType = AlternativeType.TWO_TAILED,
+        mode="auto",
+        shape: float = 1.0,
+        scale: float = 1.0,
+    ):
+        AbstractParetoGofStatistic.__init__(self, shape=shape, scale=scale)
+        KSStatistic.__init__(self, alternative_type=alternative_type, mode=mode)
+
+    @staticmethod
+    @override
+    def short_code():
+        return "KS"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = KolmogorovSmirnovParetoGofStatistic.short_code()
+        return f"{short_code}_{AbstractParetoGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        sorted_rvs = np.sort(np.asarray(rvs, dtype=float))
+        cdf_vals = scipy_stats.pareto.cdf(sorted_rvs, b=self.shape, scale=self.scale)
+        return KSStatistic.do_execute_statistic(self, sorted_rvs, cdf_vals)
+
+
+class AndersonDarlingParetoGofStatistic(AbstractParetoGofStatistic, ADStatistic):
+    @staticmethod
+    @override
+    def short_code():
+        return "AD"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = AndersonDarlingParetoGofStatistic.short_code()
+        return f"{short_code}_{AbstractParetoGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        sorted_rvs = np.sort(np.asarray(rvs, dtype=float))
+        log_cdf = scipy_stats.pareto.logcdf(sorted_rvs, b=self.shape, scale=self.scale)
+        log_sf = scipy_stats.pareto.logsf(sorted_rvs, b=self.shape, scale=self.scale)
+        return super().do_execute_statistic(sorted_rvs, log_cdf=log_cdf, log_sf=log_sf)
+
+
+class CramerVonMisesParetoGofStatistic(AbstractParetoGofStatistic, CrammerVonMisesStatistic):
+
+    @staticmethod
+    @override
+    def short_code():
+        return "CVM"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = CramerVonMisesParetoGofStatistic.short_code()
+        return f"{short_code}_{AbstractParetoGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        sorted_rvs = np.sort(np.asarray(rvs, dtype=float))
+        cdf_vals = scipy_stats.pareto.cdf(sorted_rvs, b=self.shape, scale=self.scale)
+        return CrammerVonMisesStatistic.do_execute_statistic(self, sorted_rvs, cdf_vals)
+
+class LillieforsParetoGofStatistic(AbstractParetoGofStatistic, LillieforsTest):
+
+    def __init__(self, shape: float = 1.0, scale: float = 1.0):
+        AbstractParetoGofStatistic.__init__(self, shape=shape, scale=scale)
+
+    @staticmethod
+    @override
+    def short_code():
+        return "Lilliefors"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = LillieforsParetoGofStatistic.short_code()
+        return f"{short_code}_{AbstractParetoGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        sample = np.asarray(rvs, dtype=float)
+        n = sample.size
+        if n == 0:
+            raise ValueError("At least one observation is required for the Lilliefors statistic.")
+        
+        if np.any(sample <= 0):
+            raise ValueError("Sample values must be strictly positive for Pareto distribution.")
+        scale_hat = float(np.min(sample))
+        shape_hat = float(n / np.sum(np.log(sample / scale_hat)))
+
+        self.shape = shape_hat
+        self.scale = scale_hat
+
+        sorted_sample = np.sort(sample)
+        cdf_vals = scipy_stats.pareto.cdf(sorted_sample, b=shape_hat, scale=scale_hat)
+        
+        return super().do_execute_statistic(sorted_sample, cdf_vals)
+
+
+class MinToshiyukiParetoGofStatistic(AbstractParetoGofStatistic, MinToshiyukiStatistic):
+    @staticmethod
+    @override
+    def short_code():
+        return "MT"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = MinToshiyukiParetoGofStatistic.short_code()
+        return f"{short_code}_{AbstractParetoGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        sorted_rvs = np.sort(np.asarray(rvs, dtype=float))
+        cdf_vals = scipy_stats.pareto.cdf(sorted_rvs, b=self.shape, scale=self.scale)
+        
+        cdf_vals = np.clip(cdf_vals, 1e-15, 1.0 - 1e-15)
+        
+        return super().do_execute_statistic(cdf_vals)
+    
+class ObradovicParetoGofStatistic(AbstractParetoGofStatistic):
+    """
+    Obradovic-Jovanovic-Milosevic U-statistic goodness-of-fit test for Pareto distribution.
+    
+    This statistic is based on a new characterization: X and max(X/Y, Y/X) are identically 
+    distributed if and only if X follows a Pareto distribution.
+    
+    References:
+        - Obradovic M., Jovanovic M., Milosevic B. (2014). Goodness of Fit Tests 
+          for Pareto Distribution Based on a Characterization and their Asymptotics.
+          arXiv:1310.5510v2
+    """
+
+    @staticmethod
+    @override
+    def short_code():
+        return "OJM_Integral"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = ObradovicParetoGofStatistic.short_code()
+        return f"{short_code}_{AbstractParetoGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        """
+        Execute the Obradovic et al. integral test statistic (Tn) for Pareto distribution.
+        
+        :param rvs: array of observations.
+        :return: Tn test statistic value.
+        """
+        x = np.asarray(rvs, dtype=float)
+        n = x.size
+        if n < 2:
+            raise ValueError("At least 2 observations are required for this statistic.")
+            
+        if np.any(x <= 0):
+            raise ValueError("Sample values must be strictly positive.")
+
+        N = n * (n - 1) // 2
+        
+        idx_j, idx_k = np.triu_indices(n, k=1)
+        pairs_max = np.maximum(x[idx_j] / x[idx_k], x[idx_k] / x[idx_j])
+        
+        pooled = np.concatenate([x, pairs_max])
+        
+        from scipy.stats import rankdata
+        all_ranks = rankdata(pooled, method='average')
+        
+        r_j = all_ranks[:n]
+
+        numerator = 2 * np.sum(r_j) - (n + 1) * (n + N)
+        denominator = 2 * n * N
+        
+        return float(numerator / denominator)
+    
+class GreenwoodParetoGofStatistic(AbstractParetoGofStatistic):
+    """
+    Greenwood's goodness-of-fit statistic for the Pareto distribution.
+
+    This statistic tests the Pareto assumption by transforming the sample
+    via Y_i = ln(X_i / min(X)) and evaluating Greenwood's statistic on the 
+    resulting exponentially distributed spacing candidates.
+
+    References:
+        - Greenwood, M. (1946). The statistical study of infectious diseases. 
+          Journal of the Royal Statistical Society, 109(2), 85-110.
+    """
+
+    @staticmethod
+    @override
+    def short_code():
+        return "Greenwood"
+
+    @staticmethod
+    @override
+    def code():
+        short_code = GreenwoodParetoGofStatistic.short_code()
+        return f"{short_code}_{AbstractParetoGofStatistic.code()}"
+
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        """
+        Execute Greenwood's test statistic for Pareto distribution.
+
+        :param rvs: array of observations assumed to follow Pareto.
+        :return: Greenwood's G statistic value.
+        :raises ValueError: if sample size is less than 2 or values are non-positive.
+        """
+        sample = np.asarray(rvs, dtype=float)
+        n = sample.size
+        if n < 2:
+            raise ValueError("At least 2 observations are required for Greenwood statistic.")
+
+        scale_hat = np.min(sample)
+        if scale_hat <= 0:
+            raise ValueError("Sample values must be strictly positive for Pareto distribution.")
+
+        y = np.log(sample / scale_hat)
+
+        sum_y = np.sum(y)
+        if sum_y == 0:
+            return 1.0
+
+        g = np.sum(y**2) / (sum_y**2)
+
+        return float(g)
+    
+class LequesneKlParetoGofStatistic(AbstractParetoGofStatistic):
+    """
+    Lequesne's entropy-based goodness-of-fit test for Pareto distribution
+    using Kullback-Leibler divergence and Vasicek's entropy estimator.
+    
+    References:
+        - Lequesne, J. (2013). Entropy-based goodness-of-fit test: Application 
+          to the Pareto distribution. AIP Conference Proceedings, 1553, 155-162.
+    """
+
+    @staticmethod
+    @override
+    def short_code():
+        return "Lequesne_KL"
+
+    @staticmethod
+    @override
+    def code():
+        return f"{LequesneKlParetoGofStatistic.short_code()}_{AbstractParetoGofStatistic.code()}"
+
+    @override
+    @override
+    def execute_statistic(self, rvs, **kwargs):
+        x = np.asarray(rvs, dtype=float)
+        n = x.size
+        if n < 4:
+            raise ValueError("Lequesne's KL statistic requires n >= 4 for reliable window spacing.")
+
+        sigma_hat = np.min(x)
+        if sigma_hat <= 0:
+            raise ValueError("Sample values must be strictly positive.")
+        beta_hat = n / np.sum(np.log(x / sigma_hat))
+
+
+        m = kwargs.get('m', int(np.floor(np.sqrt(n))))
+        if m < 1 or m >= n // 2:
+            m = max(1, n // 4)
+
+        x_sorted = np.sort(x)
+
+        def get_order_stat(idx):
+            if idx < 1:
+                return x_sorted[0]
+            elif idx > n:
+                return x_sorted[-1]
+            return x_sorted[idx - 1]
+
+        vasicek_sum = 0.0
+        for i in range(1, n + 1):
+            diff = get_order_stat(i + m) - get_order_stat(i - m)
+            if diff <= 0:
+                diff = 1e-10 
+            vasicek_sum += np.log((n / (2 * m)) * diff)
+        v_mn = vasicek_sum / n
+
+        mean_log_scaled = np.mean(np.log(x / sigma_hat))
+
+        kl_div = - v_mn - np.log(beta_hat) + np.log(sigma_hat) + (beta_hat + 1) * mean_log_scaled
+
+        return float(np.abs(kl_div))

--- a/tests/distributions/test_pareto.py
+++ b/tests/distributions/test_pareto.py
@@ -1,0 +1,437 @@
+import math
+
+import numpy as np
+import pytest
+import scipy.stats as scipy_stats
+
+from pysatl_criterion.statistics.alternative import AlternativeType, RightAlternative
+from pysatl_criterion.statistics.goodness_of_fit.pareto import (
+    AbstractParetoGofStatistic,
+    AndersonDarlingParetoGofStatistic,
+    KolmogorovSmirnovParetoGofStatistic,
+    CramerVonMisesParetoGofStatistic,
+    LillieforsParetoGofStatistic,
+    MinToshiyukiParetoGofStatistic,
+    ObradovicParetoGofStatistic,
+    GreenwoodParetoGofStatistic,
+    LequesneKlParetoGofStatistic,
+)
+
+
+class ConcreteGreenwoodParetoGofStatistic(GreenwoodParetoGofStatistic):
+    def alternative(self):
+        return RightAlternative()
+
+
+class ConcreteLequesneKlParetoGofStatistic(LequesneKlParetoGofStatistic):
+    def alternative(self):
+        return RightAlternative()
+
+
+class ConcreteObradovicParetoGofStatistic(ObradovicParetoGofStatistic):
+    def alternative(self):
+        return RightAlternative()
+
+def test_abstract_pareto_criterion_code():
+    assert "PARETO_GOODNESS_OF_FIT" == AbstractParetoGofStatistic.code()
+
+
+def test_abstract_pareto_distribution():
+    from pysatl_criterion import DistributionType
+
+    assert AbstractParetoGofStatistic.distribution() == DistributionType.PARETO
+
+
+def test_abstract_pareto_invalid_shape():
+    with pytest.raises(ValueError, match="Shape must be positive"):
+        KolmogorovSmirnovParetoGofStatistic(shape=0, scale=1)
+    with pytest.raises(ValueError, match="Shape must be positive"):
+        KolmogorovSmirnovParetoGofStatistic(shape=-1, scale=1)
+
+
+def test_abstract_pareto_invalid_scale():
+    with pytest.raises(ValueError, match="Scale must be positive"):
+        KolmogorovSmirnovParetoGofStatistic(shape=2, scale=0)
+    with pytest.raises(ValueError, match="Scale must be positive"):
+        KolmogorovSmirnovParetoGofStatistic(shape=2, scale=-1)
+
+
+def test_abstract_pareto_hypothesis():
+    stat = KolmogorovSmirnovParetoGofStatistic(shape=2.5, scale=1.5)
+    hypothesis = stat.hypothesis()
+    assert hypothesis.params is not None
+    assert hypothesis.parameters() == [2.5, 1.5]
+
+
+
+@pytest.mark.parametrize(
+    ("data", "shape", "scale", "expected"),
+    [
+        ([1.5, 2.0, 2.5, 3.0, 4.0], 2.0, 1.0, 0.55556),
+        ([1.1, 1.5, 2.0, 3.0, 5.0], 2.5, 1.0, 0.43711),
+        ([2.0, 3.0, 4.0, 5.0, 6.0], 3.0, 2.0, 0.50370),
+        ([1.1, 1.5, 2.0, 3.0, 5.0, 8.0], 2.0, 1.0, 0.41667),
+        ([2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], 3.0, 2.0, 0.58929),
+    ],
+)
+def test_ks_pareto_criterion(data, shape, scale, expected):
+    statistic = KolmogorovSmirnovParetoGofStatistic(shape=shape, scale=scale).execute_statistic(data)
+    assert expected == pytest.approx(statistic, rel=0.01)
+
+
+def test_ks_pareto_criterion_code():
+    assert "KS_PARETO_GOODNESS_OF_FIT" == KolmogorovSmirnovParetoGofStatistic().code()
+
+
+def test_ks_pareto_alternatives():
+    data = [1.5, 2.0, 2.5, 3.0, 4.0]
+
+    stat_two = KolmogorovSmirnovParetoGofStatistic(
+        shape=2.0, scale=1.0, alternative_type=AlternativeType.TWO_TAILED
+    )
+    stat_left = KolmogorovSmirnovParetoGofStatistic(
+        shape=2.0, scale=1.0, alternative_type=AlternativeType.LEFT
+    )
+    stat_right = KolmogorovSmirnovParetoGofStatistic(
+        shape=2.0, scale=1.0, alternative_type=AlternativeType.RIGHT
+    )
+
+    result_two = stat_two.execute_statistic(data)
+    result_left = stat_left.execute_statistic(data)
+    result_right = stat_right.execute_statistic(data)
+
+    assert result_two >= result_left and result_two >= result_right
+
+
+def test_ks_pareto_with_scipy():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=100)
+
+    stat = KolmogorovSmirnovParetoGofStatistic(shape=2.0, scale=1.0)
+    our_result = stat.execute_statistic(sample)
+
+    scipy_result = scipy_stats.kstest(sample, scipy_stats.pareto(b=2.0, scale=1.0).cdf)
+    assert our_result == pytest.approx(scipy_result.statistic, rel=0.01)
+
+
+def test_ks_pareto_non_positive_values():
+    stat = KolmogorovSmirnovParetoGofStatistic(shape=2.0, scale=1.0)
+
+    for values in ([0, 1, 2, 3], [-1, 1, 2, 3]):
+        result = stat.execute_statistic(values)
+        assert np.isfinite(result)
+        assert 0 <= result <= 1
+
+
+@pytest.mark.parametrize(
+    ("data", "shape", "scale", "expected"),
+    [
+        ([1.5, 2.0, 2.5, 3.0, 4.0], 2.0, 1.0, 2.8515060009180715),
+        ([1.1, 1.5, 2.0, 3.0, 5.0], 2.5, 1.0, 1.9340733401157904),
+        ([2.0, 3.0, 4.0, 5.0, 6.0], 3.0, 2.0, math.inf),
+        ([1.1, 1.5, 2.0, 3.0, 5.0, 8.0], 2.0, 1.0, 2.369839910981966),
+    ],
+)
+def test_ad_pareto_criterion(data, shape, scale, expected):
+    statistic = AndersonDarlingParetoGofStatistic(shape=shape, scale=scale).execute_statistic(data)
+    if math.isinf(expected):
+        assert math.isinf(statistic)
+    else:
+        assert expected == pytest.approx(statistic, rel=0.05)
+
+
+def test_ad_pareto_criterion_code():
+    assert "AD_PARETO_GOODNESS_OF_FIT" == AndersonDarlingParetoGofStatistic().code()
+
+
+def test_ad_pareto_positive():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = AndersonDarlingParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert result > 0
+
+
+@pytest.mark.parametrize(
+    ("data", "shape", "scale", "expected"),
+    [
+        ([1.5, 2.0, 2.5, 3.0, 4.0], 2.0, 1.0, 0.5793827932098767),
+        ([1.1, 1.5, 2.0, 3.0, 5.0], 2.5, 1.0, 0.30969962012912966),
+        ([2.0, 3.0, 4.0, 5.0, 6.0], 3.0, 2.0, 0.38992868175582995),
+        ([1.1, 1.5, 2.0, 3.0, 5.0, 8.0], 2.0, 1.0, 0.36855253145583944),
+    ],
+)
+def test_cvm_pareto_criterion(data, shape, scale, expected):
+    statistic = CramerVonMisesParetoGofStatistic(shape=shape, scale=scale).execute_statistic(data)
+    assert expected == pytest.approx(statistic, rel=0.05)
+
+
+def test_cvm_pareto_criterion_code():
+    assert "CVM_PARETO_GOODNESS_OF_FIT" == CramerVonMisesParetoGofStatistic().code()
+
+
+def test_cvm_pareto_positive():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = CramerVonMisesParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert result > 0
+
+def test_lilliefors_pareto_criterion_code():
+    assert "Lilliefors_PARETO_GOODNESS_OF_FIT" == LillieforsParetoGofStatistic().code()
+
+
+def test_lilliefors_pareto_positive():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = LillieforsParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert result > 0
+
+
+def test_lilliefors_pareto_less_than_one():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = LillieforsParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert result < 1
+
+
+def test_lilliefors_pareto_estimates_parameters():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=10)
+    stat = LillieforsParetoGofStatistic(shape=2.0, scale=1.0)
+    stat.execute_statistic(sample)
+
+    assert stat.shape > 0
+    assert stat.scale > 0
+    assert stat.scale == pytest.approx(np.min(sample))
+
+
+def test_lilliefors_pareto_empty_sample():
+    stat = LillieforsParetoGofStatistic(shape=2.0, scale=1.0)
+    with pytest.raises(ValueError, match="At least one observation is required"):
+        stat.execute_statistic(np.array([]))
+
+
+def test_lilliefors_pareto_constant_sample():
+    stat = LillieforsParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(np.ones(10) * 2.0)
+    assert result == 1.0
+    assert np.isinf(stat.shape)
+
+
+def test_lilliefors_pareto_non_positive_values():
+    stat = LillieforsParetoGofStatistic(shape=2.0, scale=1.0)
+
+    with pytest.raises(ValueError, match="Sample values must be strictly positive"):
+        stat.execute_statistic([0, 1, 2, 3])
+    with pytest.raises(ValueError, match="Sample values must be strictly positive"):
+        stat.execute_statistic([-1, 1, 2, 3])
+
+
+def test_mt_pareto_criterion_code():
+    assert "MT_PARETO_GOODNESS_OF_FIT" == MinToshiyukiParetoGofStatistic().code()
+
+
+def test_mt_pareto_positive():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = MinToshiyukiParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert result > 0
+
+
+def test_mt_pareto_finite():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = MinToshiyukiParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert np.isfinite(result)
+
+
+@pytest.mark.parametrize(
+    ("data", "shape", "scale"),
+    [
+        ([1.1, 1.5, 2.0, 3.0, 5.0], 2.0, 1.0),
+        ([1.5, 2.0, 2.5, 3.0, 4.0, 5.0], 2.5, 1.0),
+        ([2.0, 3.0, 4.0, 5.0, 6.0], 3.0, 2.0),
+    ],
+)
+def test_mt_pareto_finite_values(data, shape, scale):
+    stat = MinToshiyukiParetoGofStatistic(shape=shape, scale=scale)
+    result = stat.execute_statistic(data)
+    assert np.isfinite(result)
+    assert result > 0
+
+
+def test_obradovic_pareto_criterion_code():
+    assert "OJM_Integral_PARETO_GOODNESS_OF_FIT" == ConcreteObradovicParetoGofStatistic().code()
+
+
+def test_obradovic_pareto_finite():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = ConcreteObradovicParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert np.isfinite(result)
+
+
+def test_obradovic_pareto_small_sample():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=5)
+    stat = ConcreteObradovicParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert np.isfinite(result)
+
+
+def test_obradovic_pareto_too_small_sample():
+    stat = ConcreteObradovicParetoGofStatistic(shape=2.0, scale=1.0)
+    with pytest.raises(ValueError, match="At least 2 observations are required"):
+        stat.execute_statistic([1.0])
+
+
+def test_obradovic_pareto_non_positive_values():
+    stat = ConcreteObradovicParetoGofStatistic(shape=2.0, scale=1.0)
+    with pytest.raises(ValueError, match="Sample values must be strictly positive"):
+        stat.execute_statistic([0, 1, 2, 3, 4])
+    with pytest.raises(ValueError, match="Sample values must be strictly positive"):
+        stat.execute_statistic([-1, 1, 2, 3, 4])
+
+
+def test_greenwood_pareto_criterion_code():
+    assert "Greenwood_PARETO_GOODNESS_OF_FIT" == ConcreteGreenwoodParetoGofStatistic().code()
+
+
+def test_greenwood_pareto_range():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = ConcreteGreenwoodParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert 0 <= result <= 1
+
+
+def test_greenwood_pareto_constant_sample():
+    stat = ConcreteGreenwoodParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(np.ones(10) * 2.0)
+    assert result == 1.0
+
+
+def test_greenwood_pareto_too_small_sample():
+    stat = ConcreteGreenwoodParetoGofStatistic(shape=2.0, scale=1.0)
+    with pytest.raises(ValueError, match="At least 2 observations are required"):
+        stat.execute_statistic([1.0])
+
+
+def test_greenwood_pareto_non_positive_values():
+    stat = ConcreteGreenwoodParetoGofStatistic(shape=2.0, scale=1.0)
+    with pytest.raises(ValueError, match="Sample values must be strictly positive"):
+        stat.execute_statistic([0, 1, 2, 3, 4])
+    with pytest.raises(ValueError, match="Sample values must be strictly positive"):
+        stat.execute_statistic([-1, 1, 2, 3, 4])
+
+
+def test_lequesne_pareto_criterion_code():
+    assert "Lequesne_KL_PARETO_GOODNESS_OF_FIT" == ConcreteLequesneKlParetoGofStatistic().code()
+
+
+def test_lequesne_pareto_non_negative():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = ConcreteLequesneKlParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(sample)
+    assert result >= 0
+
+
+def test_lequesne_pareto_custom_window():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=50)
+    stat = ConcreteLequesneKlParetoGofStatistic(shape=2.0, scale=1.0)
+
+    result_default = stat.execute_statistic(sample)
+    result_custom = stat.execute_statistic(sample, m=5)
+
+    assert np.isfinite(result_custom)
+    assert result_default >= 0
+    assert result_custom >= 0
+
+
+def test_lequesne_pareto_small_sample():
+    stat = ConcreteLequesneKlParetoGofStatistic(shape=2.0, scale=1.0)
+    with pytest.raises(ValueError, match="requires n >= 4"):
+        stat.execute_statistic([1.0, 2.0, 3.0])
+
+
+def test_lequesne_pareto_non_positive_values():
+    stat = ConcreteLequesneKlParetoGofStatistic(shape=2.0, scale=1.0)
+    with pytest.raises(ValueError, match="Sample values must be strictly positive"):
+        stat.execute_statistic([0, 1, 2, 3, 4])
+    with pytest.raises(ValueError, match="Sample values must be strictly positive"):
+        stat.execute_statistic([-1, 1, 2, 3, 4])
+
+
+def test_all_pareto_statistics_run():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=100)
+
+    statistics = [
+        KolmogorovSmirnovParetoGofStatistic(shape=2.0, scale=1.0),
+        AndersonDarlingParetoGofStatistic(shape=2.0, scale=1.0),
+        CramerVonMisesParetoGofStatistic(shape=2.0, scale=1.0),
+        LillieforsParetoGofStatistic(shape=2.0, scale=1.0),
+        MinToshiyukiParetoGofStatistic(shape=2.0, scale=1.0),
+        ConcreteObradovicParetoGofStatistic(shape=2.0, scale=1.0),
+        ConcreteGreenwoodParetoGofStatistic(shape=2.0, scale=1.0),
+        ConcreteLequesneKlParetoGofStatistic(shape=2.0, scale=1.0),
+    ]
+
+    for stat in statistics:
+        result = stat.execute_statistic(sample)
+        assert np.isfinite(result), f"{stat.code()} returned non-finite value"
+
+
+def test_pareto_statistics_with_different_parameters():
+    np.random.seed(42)
+    sample = scipy_stats.pareto.rvs(b=3.0, scale=2.0, size=100)
+
+    statistics = [
+        KolmogorovSmirnovParetoGofStatistic(shape=3.0, scale=2.0),
+        AndersonDarlingParetoGofStatistic(shape=3.0, scale=2.0),
+        CramerVonMisesParetoGofStatistic(shape=3.0, scale=2.0),
+        ConcreteGreenwoodParetoGofStatistic(shape=3.0, scale=2.0),
+    ]
+
+    for stat in statistics:
+        result = stat.execute_statistic(sample)
+        assert np.isfinite(result), f"{stat.code()} returned non-finite value"
+
+
+def test_pareto_power_against_alternatives():
+    np.random.seed(42)
+    pareto_data = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=1000)
+    normal_data = np.random.normal(2, 1, size=1000)
+
+    stat = KolmogorovSmirnovParetoGofStatistic(shape=2.0, scale=1.0)
+
+    result_pareto = stat.execute_statistic(pareto_data)
+    result_normal = stat.execute_statistic(normal_data)
+
+    assert result_pareto < result_normal
+
+
+def test_pareto_statistics_with_large_sample():
+    np.random.seed(42)
+    large_sample = scipy_stats.pareto.rvs(b=2.0, scale=1.0, size=10000)
+
+    stat = KolmogorovSmirnovParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(large_sample)
+    assert np.isfinite(result)
+    assert result < 0.1
+
+
+def test_pareto_statistics_extreme_values():
+    data = [1.001, 1.01, 1.1, 10, 100, 1000]
+    stat = KolmogorovSmirnovParetoGofStatistic(shape=2.0, scale=1.0)
+    result = stat.execute_statistic(data)
+    assert np.isfinite(result)
+    assert 0 <= result <= 1

--- a/tests/distributions/test_pareto.py
+++ b/tests/distributions/test_pareto.py
@@ -8,13 +8,13 @@ from pysatl_criterion.statistics.alternative import AlternativeType, RightAltern
 from pysatl_criterion.statistics.goodness_of_fit.pareto import (
     AbstractParetoGofStatistic,
     AndersonDarlingParetoGofStatistic,
-    KolmogorovSmirnovParetoGofStatistic,
     CramerVonMisesParetoGofStatistic,
+    GreenwoodParetoGofStatistic,
+    KolmogorovSmirnovParetoGofStatistic,
+    LequesneKlParetoGofStatistic,
     LillieforsParetoGofStatistic,
     MinToshiyukiParetoGofStatistic,
     ObradovicParetoGofStatistic,
-    GreenwoodParetoGofStatistic,
-    LequesneKlParetoGofStatistic,
 )
 
 
@@ -31,6 +31,7 @@ class ConcreteLequesneKlParetoGofStatistic(LequesneKlParetoGofStatistic):
 class ConcreteObradovicParetoGofStatistic(ObradovicParetoGofStatistic):
     def alternative(self):
         return RightAlternative()
+
 
 def test_abstract_pareto_criterion_code():
     assert "PARETO_GOODNESS_OF_FIT" == AbstractParetoGofStatistic.code()
@@ -63,7 +64,6 @@ def test_abstract_pareto_hypothesis():
     assert hypothesis.parameters() == [2.5, 1.5]
 
 
-
 @pytest.mark.parametrize(
     ("data", "shape", "scale", "expected"),
     [
@@ -75,7 +75,9 @@ def test_abstract_pareto_hypothesis():
     ],
 )
 def test_ks_pareto_criterion(data, shape, scale, expected):
-    statistic = KolmogorovSmirnovParetoGofStatistic(shape=shape, scale=scale).execute_statistic(data)
+    statistic = KolmogorovSmirnovParetoGofStatistic(shape=shape, scale=scale).execute_statistic(
+        data
+    )
     assert expected == pytest.approx(statistic, rel=0.01)
 
 
@@ -176,6 +178,7 @@ def test_cvm_pareto_positive():
     stat = CramerVonMisesParetoGofStatistic(shape=2.0, scale=1.0)
     result = stat.execute_statistic(sample)
     assert result > 0
+
 
 def test_lilliefors_pareto_criterion_code():
     assert "Lilliefors_PARETO_GOODNESS_OF_FIT" == LillieforsParetoGofStatistic().code()


### PR DESCRIPTION
## Summary
Add goodness-of-fit statistics for the **Pareto distribution** 
Solve the issue: #53 

- **Base Architecture:** Implemented `AbstractParetoGofStatistic` for Pareto-specific statistics.
- **Classic EDF Statistics:** Added support for Kolmogorov-Smirnov (`KS`), Anderson-Darling (`AD`), Cramér–von Mises (`CVM`), parameter-adaptive `Lilliefors`, and `Min Toshiyuki`.
- **Specialized Statistics:**
  - `Obradovic` (U-statistic based on characterization).
  - `Greenwood` (spacing-based test).
  - `Lequesne` (entropy & KL divergence test).
- **Testing:** Added unit tests covering logic, edge cases, and parameter validation for all Pareto GoF criteria.

## How to Test
Run pytest for the Pareto statistics test suite:
```bash
poetry run pytest