### PR TITLE
feat: add MLE and Method of Moments estimators

### DIFF
--- a/src/pysatl_criterion/distribution/distribution_type.py
+++ b/src/pysatl_criterion/distribution/distribution_type.py
@@ -57,6 +57,11 @@ class DistributionType(Enum):
     RAYLEIGH = "rayleigh"
     PARETO = "pareto"
     WIGNER = "wigner"
+    DISCRETE_UNIFORM = "discrete_uniform"
+    BERNOULLI = "bernoulli"
+    BINOMIAL = "binomial"
+    POISSON = "poisson"
+    GEOMETRIC = "geometric"
 
     def __new__(cls, value: str):
         """

--- a/src/pysatl_criterion/distribution/distribution_type.py
+++ b/src/pysatl_criterion/distribution/distribution_type.py
@@ -53,6 +53,10 @@ class DistributionType(Enum):
     SCALE_CON_NORMAL = "scale_con_normal"
     TRUNC_NORMAL = "trunc_normal"
     TUKEY = "tukey"
+    FISHER = "fisher"
+    RAYLEIGH = "rayleigh"
+    PARETO = "pareto"
+    WIGNER = "wigner"
 
     def __new__(cls, value: str):
         """

--- a/src/pysatl_criterion/estimation/base.py
+++ b/src/pysatl_criterion/estimation/base.py
@@ -38,7 +38,7 @@ class AbstractParameterEstimator(ABC):
         """
 
     @abstractmethod
-    def estimate(self, data: list[float] | tuple[float, ...] | object) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         """
         Estimate distribution parameters from sample data.
 

--- a/src/pysatl_criterion/estimation/base.py
+++ b/src/pysatl_criterion/estimation/base.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+
+from pysatl_criterion.distribution.distribution_type import DistributionType
+
+
+class EstimationMethod(Enum):
+    """
+    Enumerate supported parameter estimation methods.
+    """
+
+    MLE = "mle"
+    MM = "mm"
+
+
+class AbstractParameterEstimator(ABC):
+    """
+    Base interface for distribution parameter estimators.
+
+    Each concrete estimator is responsible for a single distribution type and a
+    single estimation method.
+    """
+
+    @staticmethod
+    @abstractmethod
+    def distribution_type() -> DistributionType:
+        """
+        Return the distribution type handled by the estimator.
+        """
+
+    @staticmethod
+    @abstractmethod
+    def method() -> EstimationMethod:
+        """
+        Return the estimation method implemented by the estimator.
+        """
+
+    @abstractmethod
+    def estimate(self, data: list[float] | tuple[float, ...] | object) -> dict[str, float]:
+        """
+        Estimate distribution parameters from sample data.
+
+        The returned dictionary keys must match the ``name`` field of the
+        corresponding ``DistributionParameterDescriptor`` entries.
+        """

--- a/src/pysatl_criterion/estimation/maximum_likelihood/estimators.py
+++ b/src/pysatl_criterion/estimation/maximum_likelihood/estimators.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from math import comb, exp, factorial, log, pi, sqrt
-
 import numpy as np
-from scipy.optimize import minimize_scalar, root_scalar
-from scipy.special import gammaln
-from scipy.stats import beta, cauchy, chi2, f, gamma, laplace, lognorm, pareto, rayleigh, t, weibull_min
+from scipy.optimize import minimize_scalar
+from scipy.stats import beta, cauchy, chi2, f, gamma, rayleigh, t, weibull_min
 
 from pysatl_criterion.distribution.distribution_type import DistributionType
 from pysatl_criterion.estimation.base import AbstractParameterEstimator, EstimationMethod
@@ -130,7 +127,9 @@ class BetaMleEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any((sample <= 0) | (sample >= 1)):
-            raise ValueError("Beta distribution requires values strictly inside the interval (0, 1).")
+            raise ValueError(
+                "Beta distribution requires values strictly inside the interval (0, 1)."
+            )
 
         alpha, beta_param, _, _ = beta.fit(sample, floc=0, fscale=1)
         return {"a": float(alpha), "b": float(beta_param)}
@@ -229,9 +228,12 @@ class RayleighMleEstimator(AbstractParameterEstimator):
 class WignerMleEstimator(AbstractParameterEstimator):
     @staticmethod
     def distribution_type() -> DistributionType:
-        return DistributionType.NORMAL
+        return DistributionType.WIGNER
 
     @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.all(sample == sample[0]):
@@ -257,6 +259,7 @@ class WignerMleEstimator(AbstractParameterEstimator):
             raise ValueError("Failed to estimate Wigner parameter.")
 
         return {"R": float(result.x)}
+
 
 class ParetoMleEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -345,7 +348,11 @@ class BinomialMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray, n: int = 1) -> dict[str, float]:
+    def estimate(
+        self,
+        data: list[float] | tuple[float, ...] | np.ndarray,
+        n: int = 1,
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any((sample < 0) | (sample > n) | (~np.equal(np.mod(sample, 1), 0))):
             raise ValueError("Binomial distribution requires integer counts in [0, n].")

--- a/src/pysatl_criterion/estimation/maximum_likelihood/estimators.py
+++ b/src/pysatl_criterion/estimation/maximum_likelihood/estimators.py
@@ -17,7 +17,7 @@ class UniformMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         a = float(np.min(sample))
         b = float(np.max(sample))
@@ -33,7 +33,7 @@ class NormalMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         mean = float(np.mean(sample))
         variance = float(np.var(sample, ddof=0))
@@ -49,7 +49,7 @@ class LogNormalMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample <= 0):
             raise ValueError("Lognormal distribution requires strictly positive data.")
@@ -69,7 +69,7 @@ class ExponentialMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample < 0):
             raise ValueError("Exponential distribution requires non-negative data.")
@@ -88,7 +88,7 @@ class WeibullMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample <= 0):
             raise ValueError("Weibull distribution requires strictly positive data.")
@@ -106,7 +106,7 @@ class GammaMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample <= 0):
             raise ValueError("Gamma distribution requires strictly positive data.")
@@ -124,7 +124,7 @@ class BetaMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any((sample <= 0) | (sample >= 1)):
             raise ValueError(
@@ -144,7 +144,7 @@ class CauchyMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.all(sample == sample[0]):
             raise ValueError("Cauchy distribution requires non-degenerate data.")
@@ -162,7 +162,7 @@ class ChiSquaredMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample <= 0):
             raise ValueError("Chi-squared distribution requires strictly positive data.")
@@ -180,7 +180,7 @@ class StudentMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.all(sample == sample[0]):
             raise ValueError("Student distribution requires non-degenerate data.")
@@ -198,7 +198,7 @@ class FisherMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample <= 0) or np.all(sample == sample[0]):
             raise ValueError("Fisher distribution requires strictly positive, non-degenerate data.")
@@ -216,7 +216,7 @@ class RayleighMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample < 0):
             raise ValueError("Rayleigh distribution requires non-negative data.")
@@ -234,7 +234,7 @@ class WignerMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.all(sample == sample[0]):
             raise ValueError("Wigner distribution requires non-degenerate data.")
@@ -270,7 +270,7 @@ class ParetoMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample <= 0):
             raise ValueError("Pareto distribution requires strictly positive data.")
@@ -295,7 +295,7 @@ class LaplaceMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         mu = float(np.median(sample))
         b = float(np.mean(np.abs(sample - mu)))
@@ -314,7 +314,7 @@ class DiscreteUniformMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         a = float(np.min(sample))
         b = float(np.max(sample))
@@ -330,7 +330,7 @@ class BernoulliMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if not np.all(np.isin(sample, [0, 1])):
             raise ValueError("Bernoulli distribution requires binary data.")
@@ -340,6 +340,11 @@ class BernoulliMleEstimator(AbstractParameterEstimator):
 
 
 class BinomialMleEstimator(AbstractParameterEstimator):
+    def __init__(self, n: int) -> None:
+        if n <= 0:
+            raise ValueError("Number of trials n must be positive.")
+        self.n = n
+
     @staticmethod
     def distribution_type() -> DistributionType:
         return DistributionType.UNIFORM
@@ -348,16 +353,12 @@ class BinomialMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(
-        self,
-        data: list[float] | tuple[float, ...] | np.ndarray,
-        n: int = 1,
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
-        if np.any((sample < 0) | (sample > n) | (~np.equal(np.mod(sample, 1), 0))):
+        if np.any((sample < 0) | (sample > self.n) | (~np.equal(np.mod(sample, 1), 0))):
             raise ValueError("Binomial distribution requires integer counts in [0, n].")
 
-        p = float(np.sum(sample) / (sample.size * n)) if n > 0 else 0.0
+        p = float(np.sum(sample) / (sample.size * self.n)) if self.n > 0 else 0.0
         return {"p": p}
 
 
@@ -370,7 +371,7 @@ class PoissonMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample < 0) or not np.all(np.floor(sample) == sample):
             raise ValueError("Poisson distribution requires non-negative integer count data.")
@@ -388,7 +389,7 @@ class GeometricMleEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MLE
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if np.any(sample < 1) or not np.all(np.floor(sample) == sample):
             raise ValueError("Geometric distribution requires positive integer data.")

--- a/src/pysatl_criterion/estimation/maximum_likelihood/estimators.py
+++ b/src/pysatl_criterion/estimation/maximum_likelihood/estimators.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+from math import comb, exp, factorial, log, pi, sqrt
+
+import numpy as np
+from scipy.optimize import minimize_scalar, root_scalar
+from scipy.special import gammaln
+from scipy.stats import beta, cauchy, chi2, f, gamma, laplace, lognorm, pareto, rayleigh, t, weibull_min
+
+from pysatl_criterion.distribution.distribution_type import DistributionType
+from pysatl_criterion.estimation.base import AbstractParameterEstimator, EstimationMethod
+
+
+class UniformMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.UNIFORM
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        a = float(np.min(sample))
+        b = float(np.max(sample))
+        return {"a": a, "b": b}
+
+
+class NormalMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.NORMAL
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        mean = float(np.mean(sample))
+        variance = float(np.var(sample, ddof=0))
+        return {"mean": mean, "var": variance}
+
+
+class LogNormalMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.LOG_NORMAL
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample <= 0):
+            raise ValueError("Lognormal distribution requires strictly positive data.")
+
+        log_data = np.log(sample)
+        mean_log = float(np.mean(log_data))
+        variance_log = float(np.var(log_data, ddof=0))
+        return {"mean": mean_log, "var": variance_log}
+
+
+class ExponentialMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.EXPONENTIAL
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample < 0):
+            raise ValueError("Exponential distribution requires non-negative data.")
+
+        mean = float(np.mean(sample))
+        lam = float(1.0 / mean) if mean > 0 else 0.0
+        return {"lam": lam}
+
+
+class WeibullMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.WEIBULL
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample <= 0):
+            raise ValueError("Weibull distribution requires strictly positive data.")
+
+        shape, _, scale = weibull_min.fit(sample, floc=0)
+        return {"a": float(scale), "k": float(shape)}
+
+
+class GammaMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.GAMMA
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample <= 0):
+            raise ValueError("Gamma distribution requires strictly positive data.")
+
+        shape, _, scale = gamma.fit(sample, floc=0)
+        return {"alfa": float(shape), "beta": float(1.0 / scale)}
+
+
+class BetaMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.BETA
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any((sample <= 0) | (sample >= 1)):
+            raise ValueError("Beta distribution requires values strictly inside the interval (0, 1).")
+
+        alpha, beta_param, _, _ = beta.fit(sample, floc=0, fscale=1)
+        return {"a": float(alpha), "b": float(beta_param)}
+
+
+class CauchyMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.CAUCHY
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.all(sample == sample[0]):
+            raise ValueError("Cauchy distribution requires non-degenerate data.")
+
+        loc, scale = cauchy.fit(sample)
+        return {"t": float(loc), "s": float(scale)}
+
+
+class ChiSquaredMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.CHI_2
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample <= 0):
+            raise ValueError("Chi-squared distribution requires strictly positive data.")
+
+        df, _, _ = chi2.fit(sample, floc=0)
+        return {"df": float(df)}
+
+
+class StudentMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.STUDENT
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.all(sample == sample[0]):
+            raise ValueError("Student distribution requires non-degenerate data.")
+
+        df, loc, scale = t.fit(sample)
+        return {"df": float(df), "loc": float(loc), "scale": float(scale)}
+
+
+class FisherMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.FISHER
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample <= 0) or np.all(sample == sample[0]):
+            raise ValueError("Fisher distribution requires strictly positive, non-degenerate data.")
+
+        dfn, dfd, loc, scale = f.fit(sample, floc=0)
+        return {"dfn": float(dfn), "dfd": float(dfd), "loc": float(loc), "scale": float(scale)}
+
+
+class RayleighMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.RAYLEIGH
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample < 0):
+            raise ValueError("Rayleigh distribution requires non-negative data.")
+
+        _, scale = rayleigh.fit(sample, floc=0)
+        return {"scale": float(scale)}
+
+
+class WignerMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.NORMAL
+
+    @staticmethod
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.all(sample == sample[0]):
+            raise ValueError("Wigner distribution requires non-degenerate data.")
+
+        max_abs_x = float(np.max(np.abs(sample)))
+        n = sample.size
+
+        def neg_log_likelihood(R: float) -> float:
+            if R <= max_abs_x:
+                return np.inf
+
+            inner = R**2 - sample**2
+            if np.any(inner <= 0):
+                return np.inf
+            return -(n * np.log(2.0 / (np.pi * R**2)) + 0.5 * np.sum(np.log(inner)))
+
+        upper_bound = max(max_abs_x * 10.0, max_abs_x + 100.0)
+        result = minimize_scalar(
+            neg_log_likelihood, bounds=(max_abs_x + 1e-6, upper_bound), method="bounded"
+        )
+        if not result.success:
+            raise ValueError("Failed to estimate Wigner parameter.")
+
+        return {"R": float(result.x)}
+
+class ParetoMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.PARETO
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample <= 0):
+            raise ValueError("Pareto distribution requires strictly positive data.")
+
+        x_m = float(np.min(sample))
+        n = sample.size
+        log_ratios = np.log(sample / x_m)
+        sum_log_ratios = float(np.sum(log_ratios))
+        if sum_log_ratios == 0:
+            raise ValueError("Pareto MLE is undefined for the current sample.")
+
+        alpha = float(n / sum_log_ratios)
+        return {"x_m": x_m, "alpha": alpha}
+
+
+class LaplaceMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.LAPLACE
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        mu = float(np.median(sample))
+        b = float(np.mean(np.abs(sample - mu)))
+        if b == 0:
+            raise ValueError("Laplace distribution requires non-degenerate data.")
+
+        return {"t": mu, "s": b}
+
+
+class DiscreteUniformMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.UNIFORM
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        a = float(np.min(sample))
+        b = float(np.max(sample))
+        return {"a": a, "b": b}
+
+
+class BernoulliMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.UNIFORM
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if not np.all(np.isin(sample, [0, 1])):
+            raise ValueError("Bernoulli distribution requires binary data.")
+
+        p = float(np.mean(sample))
+        return {"p": p}
+
+
+class BinomialMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.UNIFORM
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray, n: int = 1) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any((sample < 0) | (sample > n) | (~np.equal(np.mod(sample, 1), 0))):
+            raise ValueError("Binomial distribution requires integer counts in [0, n].")
+
+        p = float(np.sum(sample) / (sample.size * n)) if n > 0 else 0.0
+        return {"p": p}
+
+
+class PoissonMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.UNIFORM
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample < 0) or not np.all(np.floor(sample) == sample):
+            raise ValueError("Poisson distribution requires non-negative integer count data.")
+
+        lam = float(np.mean(sample))
+        return {"lam": lam}
+
+
+class GeometricMleEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.UNIFORM
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MLE
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if np.any(sample < 1) or not np.all(np.floor(sample) == sample):
+            raise ValueError("Geometric distribution requires positive integer data.")
+
+        n = sample.size
+        sum_x = float(np.sum(sample))
+        p = float(n / sum_x) if sum_x > 0 else 0.0
+        return {"p": p}

--- a/src/pysatl_criterion/estimation/method_moments/estimators.py
+++ b/src/pysatl_criterion/estimation/method_moments/estimators.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from scipy.optimize import root_scalar
-from scipy.special import gamma
+from scipy.special import gammaln
 
 from pysatl_criterion.distribution.distribution_type import DistributionType
 from pysatl_criterion.estimation.base import AbstractParameterEstimator, EstimationMethod
@@ -17,9 +17,7 @@ class NormalMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         mean = float(np.mean(sample))
         variance = float(np.var(sample, ddof=0))
@@ -35,9 +33,7 @@ class UniformMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -45,7 +41,7 @@ class UniformMmEstimator(AbstractParameterEstimator):
             )
 
         mean = float(np.mean(sample))
-        var = float(np.var(sample, ddof=0))
+        var = max(0.0, float(np.var(sample, ddof=0)))
 
         if var < 0:
             raise ValueError("Variance of the sample cannot be negative.")
@@ -66,9 +62,7 @@ class LogNormalMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -97,9 +91,7 @@ class ExponentialMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 1:
             raise ValueError("Sample cannot be empty.")
@@ -109,8 +101,12 @@ class ExponentialMmEstimator(AbstractParameterEstimator):
             )
 
         mean = float(np.mean(sample))
-        if mean <= 0:
-            raise ValueError("Sample mean must be strictly positive.")
+
+        if mean == 0.0:
+            return {"rate": float(np.inf)}
+
+        if mean < 0:
+            raise ValueError("Sample mean cannot be negative.")
 
         rate = float(1.0 / mean)
         return {"rate": rate}
@@ -125,9 +121,7 @@ class WeibullMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -141,23 +135,32 @@ class WeibullMmEstimator(AbstractParameterEstimator):
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
 
+        if var == 0.0:
+            raise ValueError("Sample variance cannot be zero for Weibull parameter estimation.")
+
         target_ratio = 1.0 + (var / (mean**2))
 
         def equation(k: float) -> float:
             if k <= 0:
                 return 1e9
-            g1 = gamma(1.0 + 1.0 / k)
-            g2 = gamma(1.0 + 2.0 / k)
-            return (g2 / (g1**2)) - target_ratio
 
-        sol = root_scalar(equation, bracket=[1e-3, 100.0], method="brentq")
-        if not sol.converged:
-            raise RuntimeError("Failed to determine parameter k for Weibull distribution.")
+            log_ratio = gammaln(1.0 + 2.0 / k) - 2.0 * gammaln(1.0 + 1.0 / k)
+            if log_ratio > 700:
+                return 1e9
+            return float(np.exp(log_ratio) - target_ratio)
 
-        shape = float(sol.root)
-        scale = float(mean / gamma(1.0 + 1.0 / shape))
+        try:
+            sol = root_scalar(equation, bracket=[0.01, 100.0], method="brentq")
+            if not sol.converged:
+                raise RuntimeError("Failed to determine parameter k for Weibull distribution.")
 
-        return {"shape": shape, "scale": scale}
+            shape = float(sol.root)
+            scale = mean / np.exp(gammaln(1.0 + 1.0 / shape))
+            return {"shape": shape, "scale": scale}
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to determine parameter k for Weibull distribution: {e}"
+            ) from e
 
 
 class GammaMmEstimator(AbstractParameterEstimator):
@@ -169,9 +172,7 @@ class GammaMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -203,9 +204,7 @@ class BetaMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -241,9 +240,7 @@ class Chi2MmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 1:
             raise ValueError("Sample cannot be empty.")
@@ -268,9 +265,7 @@ class StudentMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -297,9 +292,7 @@ class FisherMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -346,9 +339,7 @@ class RayleighMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 1:
             raise ValueError("Sample cannot be empty.")
@@ -374,16 +365,14 @@ class WignerMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
                 "At least 2 elements are required to estimate Wigner distribution parameters."
             )
 
-        var = float(np.var(sample, ddof=0))
+        var = max(0.0, float(np.var(sample, ddof=0)))
         if var <= 0:
             raise ValueError(
                 "Sample variance must be strictly positive to estimate Wigner radius parameter."
@@ -402,9 +391,7 @@ class ParetoMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -439,9 +426,7 @@ class LaplaceMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(
-        self, data: list[float] | tuple[float, ...] | np.ndarray | object
-    ) -> dict[str, float]:
+    def estimate(self, data) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -449,7 +434,7 @@ class LaplaceMmEstimator(AbstractParameterEstimator):
             )
 
         mean = float(np.mean(sample))
-        var = float(np.var(sample, ddof=0))
+        var = max(0.0, float(np.var(sample, ddof=0)))
 
         if var <= 0:
             raise ValueError(

--- a/src/pysatl_criterion/estimation/method_moments/estimators.py
+++ b/src/pysatl_criterion/estimation/method_moments/estimators.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import numpy as np
-
 from scipy.optimize import root_scalar
 from scipy.special import gamma
 
@@ -24,6 +23,7 @@ class NormalMmEstimator(AbstractParameterEstimator):
         variance = float(np.var(sample, ddof=0))
         return {"mean": mean, "var": variance}
 
+
 class UniformMmEstimator(AbstractParameterEstimator):
     @staticmethod
     def distribution_type() -> DistributionType:
@@ -36,19 +36,22 @@ class UniformMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("Для оценки параметров равномерного распределения нужно хотя бы 2 элемента.")
+            raise ValueError(
+                "At least 2 elements are required to estimate uniform distribution parameters."
+            )
 
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
-        
+
         if var < 0:
-            raise ValueError("Дисперсия выборки не может быть отрицательной.")
+            raise ValueError("Variance of the sample cannot be negative.")
 
         half_width = np.sqrt(3.0 * var)
         a = mean - half_width
         b = mean + half_width
 
         return {"a": float(a), "b": float(b)}
+
 
 class LogNormalMmEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -62,18 +65,23 @@ class LogNormalMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("Для оценки параметров логнормального распределения нужно хотя бы 2 элемента.")
+            raise ValueError(
+                "At least 2 elements are required to estimate lognormal distribution parameters."
+            )
         if np.any(sample <= 0):
-            raise ValueError("Все элементы выборки для логнормального распределения должны быть строго больше 0.")
+            raise ValueError(
+                "All lognormal distribution sample elements must be strictly positive."
+            )
 
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
 
-        var_log = float(np.log(1.0 + var / (mean ** 2)))
+        var_log = float(np.log(1.0 + var / (mean**2)))
         mean_log = float(np.log(mean) - 0.5 * var_log)
 
         return {"mean": mean_log, "var": var_log}
-    
+
+
 class ExponentialMmEstimator(AbstractParameterEstimator):
     @staticmethod
     def distribution_type() -> DistributionType:
@@ -86,16 +94,19 @@ class ExponentialMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 1:
-            raise ValueError("Выборка не может быть пустой.")
+            raise ValueError("Sample cannot be empty.")
         if np.any(sample < 0):
-            raise ValueError("Элементы выборки для экспоненциального распределения должны быть неотрицательными.")
+            raise ValueError(
+                "All sample elements for exponential distribution must be non-negative."
+            )
 
         mean = float(np.mean(sample))
         if mean <= 0:
-            raise ValueError("Среднее значение выборки должно быть строго больше 0.")
+            raise ValueError("Sample mean must be strictly positive.")
 
         rate = float(1.0 / mean)
         return {"rate": rate}
+
 
 class WeibullMmEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -109,29 +120,35 @@ class WeibullMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("Для оценки параметров распределения Вейбулла нужно хотя бы 2 элемента.")
+            raise ValueError(
+                "At least 2 elements are required to estimate Weibull distribution parameters."
+            )
         if np.any(sample <= 0):
-            raise ValueError("Все элементы выборки для Вейбулла должны быть строго больше 0.")
+            raise ValueError(
+                "All sample elements for Weibull distribution must be strictly positive."
+            )
 
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
 
-        target_ratio = 1.0 + (var / (mean ** 2))
+        target_ratio = 1.0 + (var / (mean**2))
+
         def equation(k: float) -> float:
             if k <= 0:
                 return 1e9
             g1 = gamma(1.0 + 1.0 / k)
             g2 = gamma(1.0 + 2.0 / k)
-            return (g2 / (g1 ** 2)) - target_ratio
+            return (g2 / (g1**2)) - target_ratio
 
-        sol = root_scalar(equation, bracket=[1e-3, 100.0], method='brentq')
+        sol = root_scalar(equation, bracket=[1e-3, 100.0], method="brentq")
         if not sol.converged:
-            raise RuntimeError("Не удалось определить параметр k для распределения Вейбулла.")
+            raise RuntimeError("Failed to determine parameter k for Weibull distribution.")
 
         shape = float(sol.root)
         scale = float(mean / gamma(1.0 + 1.0 / shape))
 
         return {"shape": shape, "scale": scale}
+
 
 class GammaMmEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -145,22 +162,26 @@ class GammaMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("Для оценки параметров Гамма-распределения нужно хотя бы 2 элемента.")
+            raise ValueError(
+                "At least 2 sample elements are required to estimate Gamma distribution parameters."
+            )
         if np.any(sample <= 0):
-            raise ValueError("Все элементы выборки для Гамма-распределения должны быть строго больше 0.")
+            raise ValueError(
+                "All sample elements for Gamma distribution must be strictly positive."
+            )
 
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
 
         if var <= 0:
-            raise ValueError("Дисперсия выборки должна быть больше 0.")
+            raise ValueError("Variance of the sample cannot be negative.")
 
-        # Оценка параметров формы (shape) и масштаба (scale)
-        shape = float((mean ** 2) / var)
+        shape = float((mean**2) / var)
         scale = float(var / mean)
 
         return {"shape": shape, "scale": scale}
-    
+
+
 class BetaMmEstimator(AbstractParameterEstimator):
     @staticmethod
     def distribution_type() -> DistributionType:
@@ -173,22 +194,29 @@ class BetaMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("At least 2 elements are required to estimate Beta distribution parameters.")
+            raise ValueError(
+                "At least 2 elements are required to estimate Beta distribution parameters."
+            )
         if np.any((sample <= 0) | (sample >= 1)):
-            raise ValueError("All sample elements for Beta distribution must lie strictly in the interval (0, 1).")
+            raise ValueError(
+                "All sample elements for Beta distribution must lie strictly in (0, 1)."
+            )
 
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
 
         max_possible_var = mean * (1.0 - mean)
         if var >= max_possible_var or var <= 0:
-            raise ValueError("Sample variance must be strictly positive and less than mean * (1 - mean).")
+            raise ValueError(
+                "Sample variance must be strictly positive and less than mean * (1 - mean)."
+            )
 
         common_factor = (max_possible_var / var) - 1.0
         alpha = float(mean * common_factor)
         beta = float((1.0 - mean) * common_factor)
 
         return {"alpha": alpha, "beta": beta}
+
 
 class Chi2MmEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -208,9 +236,12 @@ class Chi2MmEstimator(AbstractParameterEstimator):
 
         mean = float(np.mean(sample))
         if mean <= 0:
-            raise ValueError("Sample mean must be strictly positive to estimate degrees of freedom.")
+            raise ValueError(
+                "Sample mean must be strictly positive to estimate degrees of freedom."
+            )
 
         return {"df": mean}
+
 
 class StudentMmEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -224,22 +255,25 @@ class StudentMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("At least 2 elements are required to estimate Student's t-distribution parameters.")
+            raise ValueError(
+                "At least 2 elements are required to estimate Student's t-distribution parameters."
+            )
 
         var = float(np.var(sample, ddof=0))
         if var <= 1.0:
             raise ValueError(
-                "Sample variance must be strictly greater than 1.0 "
-                "to estimate degrees of freedom for Student's t-distribution using Method of Moments."
+                "Sample variance must be strictly greater than 1.0 to estimate "
+                "degrees of freedom for Student's t-distribution via Method of Moments."
             )
 
         df = float((2.0 * var) / (var - 1.0))
         return {"df": df}
 
+
 class FisherMmEstimator(AbstractParameterEstimator):
     @staticmethod
     def distribution_type() -> DistributionType:
-        return DistributionType.FISHER  
+        return DistributionType.FISHER
 
     @staticmethod
     def method() -> EstimationMethod:
@@ -248,9 +282,13 @@ class FisherMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("At least 2 elements are required to estimate Fisher F-distribution parameters.")
+            raise ValueError(
+                "At least 2 elements are required to estimate Fisher F-distribution parameters."
+            )
         if np.any(sample <= 0):
-            raise ValueError("All sample elements for Fisher distribution must be strictly positive.")
+            raise ValueError(
+                "All sample elements for Fisher distribution must be strictly positive."
+            )
 
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
@@ -261,7 +299,6 @@ class FisherMmEstimator(AbstractParameterEstimator):
                 "to estimate valid denominator degrees of freedom (df2 > 2)."
             )
 
-        # Estimate denominator degrees of freedom (df2)
         df2 = float((2.0 * mean) / (mean - 1.0))
         if df2 <= 4.0:
             raise ValueError(
@@ -269,20 +306,21 @@ class FisherMmEstimator(AbstractParameterEstimator):
                 "for variance to be finite."
             )
 
-        # Intermediate parameter A = S^2 * (df2 - 4) / (2 * mean^2)
-        a_param = (var * (df2 - 4.0)) / (2.0 * (mean ** 2))
+        a_param = (var * (df2 - 4.0)) / (2.0 * (mean**2))
         if a_param <= 1.0:
-            raise ValueError("Calculated variance is too small to yield a positive numerator degrees of freedom (df1).")
+            raise ValueError(
+                "Calculated variance is too small to yield positive numerator df (df1)."
+            )
 
-        # Estimate numerator degrees of freedom (df1)
         df1 = float((df2 - 2.0) / (a_param - 1.0))
 
         return {"df1": df1, "df2": df2}
 
+
 class RayleighMmEstimator(AbstractParameterEstimator):
     @staticmethod
     def distribution_type() -> DistributionType:
-        return DistributionType.RAYLEIGH 
+        return DistributionType.RAYLEIGH
 
     @staticmethod
     def method() -> EstimationMethod:
@@ -297,10 +335,13 @@ class RayleighMmEstimator(AbstractParameterEstimator):
 
         mean = float(np.mean(sample))
         if mean <= 0:
-            raise ValueError("Sample mean must be strictly positive to estimate Rayleigh scale parameter.")
+            raise ValueError(
+                "Sample mean must be strictly positive to estimate Rayleigh scale parameter."
+            )
 
         scale = float(mean * np.sqrt(2.0 / np.pi))
         return {"scale": scale}
+
 
 class WignerMmEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -314,14 +355,19 @@ class WignerMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("At least 2 elements are required to estimate Wigner distribution parameters.")
+            raise ValueError(
+                "At least 2 elements are required to estimate Wigner distribution parameters."
+            )
 
         var = float(np.var(sample, ddof=0))
         if var <= 0:
-            raise ValueError("Sample variance must be strictly positive to estimate Wigner radius parameter.")
+            raise ValueError(
+                "Sample variance must be strictly positive to estimate Wigner radius parameter."
+            )
 
         radius = float(2.0 * np.sqrt(var))
         return {"radius": radius}
+
 
 class ParetoMmEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -335,23 +381,28 @@ class ParetoMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("At least 2 elements are required to estimate Pareto distribution parameters.")
+            raise ValueError(
+                "At least 2 elements are required to estimate Pareto distribution parameters."
+            )
         if np.any(sample <= 0):
-            raise ValueError("All sample elements for Pareto distribution must be strictly positive.")
+            raise ValueError(
+                "All sample elements for Pareto distribution must be strictly positive."
+            )
 
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
 
         if var <= 0:
-            raise ValueError("Sample variance must be strictly positive to estimate Pareto parameters.")
+            raise ValueError(
+                "Sample variance must be strictly positive to estimate Pareto parameters."
+            )
 
-        # Estimate shape parameter alpha
-        alpha = float(1.0 + np.sqrt(1.0 + (mean ** 2) / var))
-        
-        # Estimate scale/location parameter x_m
+        alpha = float(1.0 + np.sqrt(1.0 + (mean**2) / var))
+
         scale = float(mean * (alpha - 1.0) / alpha)
 
         return {"shape": alpha, "scale": scale}
+
 
 class LaplaceMmEstimator(AbstractParameterEstimator):
     @staticmethod
@@ -365,13 +416,17 @@ class LaplaceMmEstimator(AbstractParameterEstimator):
     def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
-            raise ValueError("At least 2 elements are required to estimate Laplace distribution parameters.")
+            raise ValueError(
+                "At least 2 elements are required to estimate Laplace distribution parameters."
+            )
 
         mean = float(np.mean(sample))
         var = float(np.var(sample, ddof=0))
 
         if var <= 0:
-            raise ValueError("Sample variance must be strictly positive to estimate Laplace scale parameter.")
+            raise ValueError(
+                "Sample variance must be strictly positive to estimate Laplace scale parameter."
+            )
 
         loc = mean
         scale = float(np.sqrt(var / 2.0))

--- a/src/pysatl_criterion/estimation/method_moments/estimators.py
+++ b/src/pysatl_criterion/estimation/method_moments/estimators.py
@@ -17,7 +17,9 @@ class NormalMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         mean = float(np.mean(sample))
         variance = float(np.var(sample, ddof=0))
@@ -33,7 +35,9 @@ class UniformMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -62,7 +66,9 @@ class LogNormalMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -91,7 +97,9 @@ class ExponentialMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 1:
             raise ValueError("Sample cannot be empty.")
@@ -117,7 +125,9 @@ class WeibullMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -159,7 +169,9 @@ class GammaMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -191,7 +203,9 @@ class BetaMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -227,7 +241,9 @@ class Chi2MmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 1:
             raise ValueError("Sample cannot be empty.")
@@ -252,7 +268,9 @@ class StudentMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -279,7 +297,9 @@ class FisherMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -326,7 +346,9 @@ class RayleighMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 1:
             raise ValueError("Sample cannot be empty.")
@@ -352,7 +374,9 @@ class WignerMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -378,7 +402,9 @@ class ParetoMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(
@@ -413,7 +439,9 @@ class LaplaceMmEstimator(AbstractParameterEstimator):
     def method() -> EstimationMethod:
         return EstimationMethod.MM
 
-    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+    def estimate(
+        self, data: list[float] | tuple[float, ...] | np.ndarray | object
+    ) -> dict[str, float]:
         sample = np.asarray(data, dtype=float)
         if sample.size < 2:
             raise ValueError(

--- a/src/pysatl_criterion/estimation/method_moments/estimators.py
+++ b/src/pysatl_criterion/estimation/method_moments/estimators.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import numpy as np
+
+from scipy.optimize import root_scalar
+from scipy.special import gamma
+
+from pysatl_criterion.distribution.distribution_type import DistributionType
+from pysatl_criterion.estimation.base import AbstractParameterEstimator, EstimationMethod
+
+
+class NormalMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.NORMAL
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        mean = float(np.mean(sample))
+        variance = float(np.var(sample, ddof=0))
+        return {"mean": mean, "var": variance}
+
+class UniformMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.UNIFORM
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("Для оценки параметров равномерного распределения нужно хотя бы 2 элемента.")
+
+        mean = float(np.mean(sample))
+        var = float(np.var(sample, ddof=0))
+        
+        if var < 0:
+            raise ValueError("Дисперсия выборки не может быть отрицательной.")
+
+        half_width = np.sqrt(3.0 * var)
+        a = mean - half_width
+        b = mean + half_width
+
+        return {"a": float(a), "b": float(b)}
+
+class LogNormalMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.LOG_NORMAL
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("Для оценки параметров логнормального распределения нужно хотя бы 2 элемента.")
+        if np.any(sample <= 0):
+            raise ValueError("Все элементы выборки для логнормального распределения должны быть строго больше 0.")
+
+        mean = float(np.mean(sample))
+        var = float(np.var(sample, ddof=0))
+
+        var_log = float(np.log(1.0 + var / (mean ** 2)))
+        mean_log = float(np.log(mean) - 0.5 * var_log)
+
+        return {"mean": mean_log, "var": var_log}
+    
+class ExponentialMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.EXPONENTIAL
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 1:
+            raise ValueError("Выборка не может быть пустой.")
+        if np.any(sample < 0):
+            raise ValueError("Элементы выборки для экспоненциального распределения должны быть неотрицательными.")
+
+        mean = float(np.mean(sample))
+        if mean <= 0:
+            raise ValueError("Среднее значение выборки должно быть строго больше 0.")
+
+        rate = float(1.0 / mean)
+        return {"rate": rate}
+
+class WeibullMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.WEIBULL
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("Для оценки параметров распределения Вейбулла нужно хотя бы 2 элемента.")
+        if np.any(sample <= 0):
+            raise ValueError("Все элементы выборки для Вейбулла должны быть строго больше 0.")
+
+        mean = float(np.mean(sample))
+        var = float(np.var(sample, ddof=0))
+
+        target_ratio = 1.0 + (var / (mean ** 2))
+        def equation(k: float) -> float:
+            if k <= 0:
+                return 1e9
+            g1 = gamma(1.0 + 1.0 / k)
+            g2 = gamma(1.0 + 2.0 / k)
+            return (g2 / (g1 ** 2)) - target_ratio
+
+        sol = root_scalar(equation, bracket=[1e-3, 100.0], method='brentq')
+        if not sol.converged:
+            raise RuntimeError("Не удалось определить параметр k для распределения Вейбулла.")
+
+        shape = float(sol.root)
+        scale = float(mean / gamma(1.0 + 1.0 / shape))
+
+        return {"shape": shape, "scale": scale}
+
+class GammaMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.GAMMA
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("Для оценки параметров Гамма-распределения нужно хотя бы 2 элемента.")
+        if np.any(sample <= 0):
+            raise ValueError("Все элементы выборки для Гамма-распределения должны быть строго больше 0.")
+
+        mean = float(np.mean(sample))
+        var = float(np.var(sample, ddof=0))
+
+        if var <= 0:
+            raise ValueError("Дисперсия выборки должна быть больше 0.")
+
+        # Оценка параметров формы (shape) и масштаба (scale)
+        shape = float((mean ** 2) / var)
+        scale = float(var / mean)
+
+        return {"shape": shape, "scale": scale}
+    
+class BetaMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.BETA
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("At least 2 elements are required to estimate Beta distribution parameters.")
+        if np.any((sample <= 0) | (sample >= 1)):
+            raise ValueError("All sample elements for Beta distribution must lie strictly in the interval (0, 1).")
+
+        mean = float(np.mean(sample))
+        var = float(np.var(sample, ddof=0))
+
+        max_possible_var = mean * (1.0 - mean)
+        if var >= max_possible_var or var <= 0:
+            raise ValueError("Sample variance must be strictly positive and less than mean * (1 - mean).")
+
+        common_factor = (max_possible_var / var) - 1.0
+        alpha = float(mean * common_factor)
+        beta = float((1.0 - mean) * common_factor)
+
+        return {"alpha": alpha, "beta": beta}
+
+class Chi2MmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.CHI_2
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 1:
+            raise ValueError("Sample cannot be empty.")
+        if np.any(sample < 0):
+            raise ValueError("All elements for Chi-Square distribution must be non-negative.")
+
+        mean = float(np.mean(sample))
+        if mean <= 0:
+            raise ValueError("Sample mean must be strictly positive to estimate degrees of freedom.")
+
+        return {"df": mean}
+
+class StudentMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.STUDENT
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("At least 2 elements are required to estimate Student's t-distribution parameters.")
+
+        var = float(np.var(sample, ddof=0))
+        if var <= 1.0:
+            raise ValueError(
+                "Sample variance must be strictly greater than 1.0 "
+                "to estimate degrees of freedom for Student's t-distribution using Method of Moments."
+            )
+
+        df = float((2.0 * var) / (var - 1.0))
+        return {"df": df}
+
+class FisherMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.FISHER  
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("At least 2 elements are required to estimate Fisher F-distribution parameters.")
+        if np.any(sample <= 0):
+            raise ValueError("All sample elements for Fisher distribution must be strictly positive.")
+
+        mean = float(np.mean(sample))
+        var = float(np.var(sample, ddof=0))
+
+        if mean <= 1.0:
+            raise ValueError(
+                "Sample mean must be strictly greater than 1.0 "
+                "to estimate valid denominator degrees of freedom (df2 > 2)."
+            )
+
+        # Estimate denominator degrees of freedom (df2)
+        df2 = float((2.0 * mean) / (mean - 1.0))
+        if df2 <= 4.0:
+            raise ValueError(
+                "Estimated denominator degrees of freedom (df2) must be greater than 4.0 "
+                "for variance to be finite."
+            )
+
+        # Intermediate parameter A = S^2 * (df2 - 4) / (2 * mean^2)
+        a_param = (var * (df2 - 4.0)) / (2.0 * (mean ** 2))
+        if a_param <= 1.0:
+            raise ValueError("Calculated variance is too small to yield a positive numerator degrees of freedom (df1).")
+
+        # Estimate numerator degrees of freedom (df1)
+        df1 = float((df2 - 2.0) / (a_param - 1.0))
+
+        return {"df1": df1, "df2": df2}
+
+class RayleighMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.RAYLEIGH 
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 1:
+            raise ValueError("Sample cannot be empty.")
+        if np.any(sample < 0):
+            raise ValueError("All sample elements for Rayleigh distribution must be non-negative.")
+
+        mean = float(np.mean(sample))
+        if mean <= 0:
+            raise ValueError("Sample mean must be strictly positive to estimate Rayleigh scale parameter.")
+
+        scale = float(mean * np.sqrt(2.0 / np.pi))
+        return {"scale": scale}
+
+class WignerMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.WIGNER
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("At least 2 elements are required to estimate Wigner distribution parameters.")
+
+        var = float(np.var(sample, ddof=0))
+        if var <= 0:
+            raise ValueError("Sample variance must be strictly positive to estimate Wigner radius parameter.")
+
+        radius = float(2.0 * np.sqrt(var))
+        return {"radius": radius}
+
+class ParetoMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.PARETO
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("At least 2 elements are required to estimate Pareto distribution parameters.")
+        if np.any(sample <= 0):
+            raise ValueError("All sample elements for Pareto distribution must be strictly positive.")
+
+        mean = float(np.mean(sample))
+        var = float(np.var(sample, ddof=0))
+
+        if var <= 0:
+            raise ValueError("Sample variance must be strictly positive to estimate Pareto parameters.")
+
+        # Estimate shape parameter alpha
+        alpha = float(1.0 + np.sqrt(1.0 + (mean ** 2) / var))
+        
+        # Estimate scale/location parameter x_m
+        scale = float(mean * (alpha - 1.0) / alpha)
+
+        return {"shape": alpha, "scale": scale}
+
+class LaplaceMmEstimator(AbstractParameterEstimator):
+    @staticmethod
+    def distribution_type() -> DistributionType:
+        return DistributionType.LAPLACE
+
+    @staticmethod
+    def method() -> EstimationMethod:
+        return EstimationMethod.MM
+
+    def estimate(self, data: list[float] | tuple[float, ...] | np.ndarray) -> dict[str, float]:
+        sample = np.asarray(data, dtype=float)
+        if sample.size < 2:
+            raise ValueError("At least 2 elements are required to estimate Laplace distribution parameters.")
+
+        mean = float(np.mean(sample))
+        var = float(np.var(sample, ddof=0))
+
+        if var <= 0:
+            raise ValueError("Sample variance must be strictly positive to estimate Laplace scale parameter.")
+
+        loc = mean
+        scale = float(np.sqrt(var / 2.0))
+
+        return {"t": loc, "s": scale}

--- a/tests/estimation/test_method_moments.py
+++ b/tests/estimation/test_method_moments.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import semicircular
+
+from pysatl_criterion.distribution.distribution_type import DistributionType
+from pysatl_criterion.estimation.base import EstimationMethod
+from pysatl_criterion.estimation.method_moments.estimators import (
+    BetaMmEstimator,
+    Chi2MmEstimator,
+    ExponentialMmEstimator,
+    FisherMmEstimator,
+    GammaMmEstimator,
+    LaplaceMmEstimator,
+    LogNormalMmEstimator,
+    NormalMmEstimator,
+    ParetoMmEstimator,
+    RayleighMmEstimator,
+    StudentMmEstimator,
+    UniformMmEstimator,
+    WeibullMmEstimator,
+    WignerMmEstimator,
+)
+
+
+RNG = np.random.default_rng(42)
+
+class TestNormalMmEstimator:
+    def test_metadata(self):
+        assert NormalMmEstimator.distribution_type() == DistributionType.NORMAL
+        assert NormalMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        data = RNG.normal(loc=5.0, scale=2.0, size=10_000)
+        res = NormalMmEstimator().estimate(data)
+
+        assert res["mean"] == pytest.approx(5.0, abs=0.1)
+        assert res["var"] == pytest.approx(4.0, abs=0.2)
+
+    def test_negative_data(self):
+        data = [-10.0, -5.0, -1.0, 0.0]
+        res = NormalMmEstimator().estimate(data)
+        assert res["mean"] == pytest.approx(-4.0)
+
+    def test_all_values_equal_to_mathExpect(self):
+        data = [7.0, 7.0, 7.0, 7.0]
+        res = NormalMmEstimator().estimate(data)
+        assert res["mean"] == 7.0
+        assert res["var"] == 0.0
+
+    def test_big_and_small_distribution(self):
+        res_big = NormalMmEstimator().estimate(RNG.normal(1e6, 1e3, 1000))
+        assert res_big["mean"] == pytest.approx(1e6, rel=1e-2)
+
+        res_small = NormalMmEstimator().estimate(RNG.normal(1e-6, 1e-7, 1000))
+        assert res_small["mean"] == pytest.approx(1e-6, rel=1e-2)
+
+    def test_a_lot_of_data(self):
+        data = RNG.normal(loc=12.5, scale=np.sqrt(3.2), size=200_000)
+        res = NormalMmEstimator().estimate(data)
+        assert res["mean"] == pytest.approx(12.5, rel=1e-2)
+        assert res["var"] == pytest.approx(3.2, rel=1e-2)
+
+class TestUniformMmEstimator:
+    def test_metadata(self):
+        assert UniformMmEstimator.distribution_type() == DistributionType.UNIFORM
+        assert UniformMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        data = RNG.uniform(low=2.0, high=8.0, size=10_000)
+        res = UniformMmEstimator().estimate(data)
+
+        assert res["a"] == pytest.approx(2.0, abs=0.1)
+        assert res["b"] == pytest.approx(8.0, abs=0.1)
+
+    def test_negative_data(self):
+        data = RNG.uniform(low=-10.0, high=-2.0, size=2000)
+        res = UniformMmEstimator().estimate(data)
+        assert res["a"] == pytest.approx(-10.0, abs=0.2)
+        assert res["b"] == pytest.approx(-2.0, abs=0.2)
+
+    def test_all_values_equal_to_mathExpect(self):
+        data = [3.0, 3.0, 3.0, 3.0]
+        res = UniformMmEstimator().estimate(data)
+        assert res["a"] == pytest.approx(3.0)
+        assert res["b"] == pytest.approx(3.0)
+
+    def test_a_lot_of_data(self):
+        data = RNG.uniform(low=0.0, high=100.0, size=200_000)
+        res = UniformMmEstimator().estimate(data)
+        assert res["a"] == pytest.approx(0.0, abs=0.5)
+        assert res["b"] == pytest.approx(100.0, abs=0.5)
+
+    def test_invalid_sample_size(self):
+        with pytest.raises(ValueError, match="At least 2 elements"):
+            UniformMmEstimator().estimate([5.0])
+
+class TestLogNormalMmEstimator:
+    def test_metadata(self):
+        assert LogNormalMmEstimator.distribution_type() == DistributionType.LOG_NORMAL
+        assert LogNormalMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        data = RNG.lognormal(mean=0.5, sigma=0.5, size=20_000)
+        res = LogNormalMmEstimator().estimate(data)
+
+        assert res["mean"] == pytest.approx(0.5, abs=0.05)
+        assert res["var"] == pytest.approx(0.25, abs=0.05)
+
+    def test_negative_data(self):
+        with pytest.raises(ValueError, match="strictly positive"):
+            LogNormalMmEstimator().estimate([1.0, 2.0, -0.5])
+
+    def test_all_values_equal_to_mathExpect(self):
+        res = LogNormalMmEstimator().estimate([2.0, 2.0, 2.0])
+        assert res["mean"] == pytest.approx(np.log(2.0))
+        assert res["var"] == pytest.approx(0.0)
+
+    def test_a_lot_of_data(self):
+        data = RNG.lognormal(mean=1.2, sigma=0.4, size=100_000)
+        res = LogNormalMmEstimator().estimate(data)
+        assert res["mean"] == pytest.approx(1.2, rel=2e-2)
+        assert res["var"] == pytest.approx(0.16, rel=2e-2)
+
+
+class TestExponentialMmEstimator:
+    def test_metadata(self):
+        assert ExponentialMmEstimator.distribution_type() == DistributionType.EXPONENTIAL
+        assert ExponentialMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        data = RNG.exponential(scale=0.5, size=20_000)
+        res = ExponentialMmEstimator().estimate(data)
+
+        assert res["rate"] == pytest.approx(2.0, rel=5e-2)
+
+    def test_negative_data(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            ExponentialMmEstimator().estimate([1.0, -2.0, 3.0])
+
+    def test_all_values_equal_to_mathExpect(self):
+        res = ExponentialMmEstimator().estimate([4.0, 4.0, 4.0])
+        assert res["rate"] == pytest.approx(0.25)
+
+class TestWeibullMmEstimator:
+    def test_metadata(self):
+        assert WeibullMmEstimator.distribution_type() == DistributionType.WEIBULL
+        assert WeibullMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        shape, scale = 2.0, 3.0
+        data = scale * RNG.weibull(a=shape, size=20_000)
+        res = WeibullMmEstimator().estimate(data)
+
+        assert res["shape"] == pytest.approx(shape, rel=5e-2)
+        assert res["scale"] == pytest.approx(scale, rel=5e-2)
+
+    def test_negative_data(self):
+        with pytest.raises(ValueError, match="strictly positive"):
+            WeibullMmEstimator().estimate([1.0, -1.0])
+
+class TestGammaMmEstimator:
+    def test_metadata(self):
+        assert GammaMmEstimator.distribution_type() == DistributionType.GAMMA
+        assert GammaMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        shape, scale = 3.0, 2.0
+        data = RNG.gamma(shape=shape, scale=scale, size=20_000)
+        res = GammaMmEstimator().estimate(data)
+
+        assert res["shape"] == pytest.approx(shape, rel=5e-2)
+        assert res["scale"] == pytest.approx(scale, rel=5e-2)
+
+    def test_all_values_equal_to_mathExpect(self):
+        with pytest.raises(ValueError, match="Variance"):
+            GammaMmEstimator().estimate([4.0, 4.0, 4.0])
+
+class TestBetaMmEstimator:
+    def test_metadata(self):
+        assert BetaMmEstimator.distribution_type() == DistributionType.BETA
+        assert BetaMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        alpha, beta = 2.0, 5.0
+        data = RNG.beta(a=alpha, b=beta, size=20_000)
+        res = BetaMmEstimator().estimate(data)
+
+        assert res["alpha"] == pytest.approx(alpha, rel=5e-2)
+        assert res["beta"] == pytest.approx(beta, rel=5e-2)
+
+    def test_out_of_bounds_data(self):
+        with pytest.raises(ValueError, match=r"strictly in \(0, 1\)"):
+            BetaMmEstimator().estimate([-0.1, 0.5, 1.2])
+
+class TestChi2MmEstimator:
+    def test_metadata(self):
+        assert Chi2MmEstimator.distribution_type() == DistributionType.CHI_2
+        assert Chi2MmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        df = 4.0
+        data = RNG.chisquare(df=df, size=20_000)
+        res = Chi2MmEstimator().estimate(data)
+
+        assert res["df"] == pytest.approx(df, rel=5e-2)
+
+class TestStudentMmEstimator:
+    def test_metadata(self):
+        assert StudentMmEstimator.distribution_type() == DistributionType.STUDENT
+        assert StudentMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        df = 6.0
+        data = RNG.standard_t(df=df, size=100_000)
+        res = StudentMmEstimator().estimate(data)
+
+        assert res["df"] == pytest.approx(df, rel=0.15)
+
+
+class TestFisherMmEstimator:
+    def test_metadata(self):
+        assert FisherMmEstimator.distribution_type() == DistributionType.FISHER
+        assert FisherMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        df1, df2 = 10.0, 8.0
+        data = RNG.f(dfnum=df1, dfden=df2, size=100_000)
+        res = FisherMmEstimator().estimate(data)
+
+        assert res["df1"] == pytest.approx(df1, rel=0.15)
+        assert res["df2"] == pytest.approx(df2, rel=0.15)
+
+
+class TestRayleighMmEstimator:
+    def test_metadata(self):
+        assert RayleighMmEstimator.distribution_type() == DistributionType.RAYLEIGH
+        assert RayleighMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        scale = 3.0
+        data = RNG.rayleigh(scale=scale, size=20_000)
+        res = RayleighMmEstimator().estimate(data)
+
+        assert res["scale"] == pytest.approx(scale, rel=5e-2)
+
+class TestWignerMmEstimator:
+    def test_metadata(self):
+        assert WignerMmEstimator.distribution_type() == DistributionType.WIGNER
+        assert WignerMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        radius = 4.0
+        data = semicircular.rvs(scale=radius, size=20_000, random_state=RNG)
+        res = WignerMmEstimator().estimate(data)
+
+        assert res["radius"] == pytest.approx(radius, rel=5e-2)
+
+class TestParetoMmEstimator:
+    def test_metadata(self):
+        assert ParetoMmEstimator.distribution_type() == DistributionType.PARETO
+        assert ParetoMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        alpha, scale = 3.0, 5.0
+        data = scale * (RNG.pareto(a=alpha, size=100_000) + 1.0)
+        res = ParetoMmEstimator().estimate(data)
+
+        assert res["shape"] == pytest.approx(alpha, rel=0.1)
+        assert res["scale"] == pytest.approx(scale, rel=0.1)
+
+class TestLaplaceMmEstimator:
+    def test_metadata(self):
+        assert LaplaceMmEstimator.distribution_type() == DistributionType.LAPLACE
+        assert LaplaceMmEstimator.method() == EstimationMethod.MM
+
+    def test_estimate_success(self):
+        loc, scale = 2.0, 1.5
+        data = RNG.laplace(loc=loc, scale=scale, size=20_000)
+        res = LaplaceMmEstimator().estimate(data)
+
+        assert res["t"] == pytest.approx(loc, abs=0.1)
+        assert res["s"] == pytest.approx(scale, rel=5e-2)


### PR DESCRIPTION
# Summary
Implemented concrete parameter estimators for supported continuous and discrete probability distributions using Method of Moments (MM) and Maximum Likelihood Estimation (MLE).

Solve the issue: #73 

# Quick changelog
* **Extensible Architecture:**
  * Utilized the base `AbstractParameterEstimator` interface to allow easy addition of new estimation methods.
* **Maximum Likelihood Estimation (MLE):**
  * Implemented concrete parameter estimators located in `src/pysatl_criterion/estimation/maximum_likelihood/`.
* **Method of Moments (MM):**
  * Implemented concrete parameter estimators located in `src/pysatl_criterion/estimation/method_moments/`.