### PR TITLE
perf: optimize Anderson-Darling Laplace statistic with Numba

### DIFF
--- a/benchmarks/benchmark_anderson_darling_laplace.py
+++ b/benchmarks/benchmark_anderson_darling_laplace.py
@@ -1,0 +1,91 @@
+import time
+from collections.abc import Callable
+
+import numpy as np
+import scipy.stats as scipy_stats
+
+from pysatl_criterion.statistics.goodness_of_fit.laplace import AndersonDarlingLaplaceGofStatistic
+
+
+def anderson_darling_laplace_reference(
+    sorted_sample: np.ndarray, location: float, scale: float
+) -> float:
+    """Calculate the Anderson--Darling statistic using the original approach."""
+    n = len(sorted_sample)
+    log_cdf = scipy_stats.laplace.logcdf(
+        sorted_sample,
+        loc=location,
+        scale=scale,
+    )
+    log_sf = scipy_stats.laplace.logsf(
+        sorted_sample,
+        loc=location,
+        scale=scale,
+    )
+    i = np.arange(1, n + 1)
+    return float(-n - np.sum((2 * i - 1.0) / n * (log_cdf + log_sf[::-1])))
+
+
+def measure(function: Callable[[], float], calls: int) -> float:
+    """Measure total execution time for the requested number of calls."""
+    start = time.perf_counter()
+
+    for _ in range(calls):
+        function()
+
+    return time.perf_counter() - start
+
+
+def main() -> None:
+    location = 0.0
+    scale = 1.0
+    calls = 1_000
+    sample = np.random.default_rng(42).laplace(
+        loc=location,
+        scale=scale,
+        size=10_000,
+    )
+    sorted_sample = np.sort(sample)
+    statistic = AndersonDarlingLaplaceGofStatistic(
+        t=location,
+        s=scale,
+    )
+
+    # Compile the Numba kernel before measuring execution time.
+    optimized_result = statistic.do_execute_statistic(sorted_sample)
+    reference_result = anderson_darling_laplace_reference(
+        sorted_sample,
+        location,
+        scale,
+    )
+    np.testing.assert_allclose(optimized_result, reference_result)
+
+    reference_elapsed = measure(
+        lambda: anderson_darling_laplace_reference(
+            sorted_sample,
+            location,
+            scale,
+        ),
+        calls,
+    )
+    optimized_elapsed = measure(
+        lambda: statistic.do_execute_statistic(sorted_sample),
+        calls,
+    )
+
+    print(f"Sample size: {sample.size}")
+    print(f"Calls: {calls}")
+    print()
+    print("SciPy reference implementation:")
+    print(f"Total time: {reference_elapsed:.6f} seconds")
+    print(f"Average time per call: {reference_elapsed / calls:.9f} seconds")
+    print()
+    print("Numba implementation:")
+    print(f"Total time: {optimized_elapsed:.6f} seconds")
+    print(f"Average time per call: {optimized_elapsed / calls:.9f} seconds")
+    print()
+    print(f"Speedup: {reference_elapsed / optimized_elapsed:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ zstandard = "==0.25.0"
 python-dotenv = ">=1.0.0"
 psycopg2-binary = ">=2.9.12,<3.0.0"
 python = ">=3.10,<3.13"
+numba = "^0.66.0"
 
 [tool.poetry.urls]
 Homepage = "https://github.com/PySATL/pysatl-criterion"

--- a/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
@@ -4,6 +4,7 @@ from abc import ABC
 
 import numpy as np
 import scipy.stats as scipy_stats
+from numba import njit
 from typing_extensions import override
 
 from pysatl_criterion import DistributionType
@@ -179,6 +180,32 @@ class AndersonDarlingLaplaceGofStatistic(AbstractLaplaceGofStatistic, ADStatisti
         short_code = AndersonDarlingLaplaceGofStatistic.short_code()
         return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
 
+    @staticmethod
+    @njit
+    def _calculate_statistic(
+        sorted_rvs: np.ndarray, t: float, s: float
+    ) -> float:  # pragma: no cover
+        n = len(sorted_rvs)
+        total = 0.0
+
+        for i in range(n):
+            lower = (sorted_rvs[i] - t) / s
+            upper = (sorted_rvs[n - i - 1] - t) / s
+
+            if lower < 0.0:
+                log_cdf = np.log(0.5 * np.exp(lower))
+            else:
+                log_cdf = np.log1p(-0.5 * np.exp(-lower))
+
+            if upper < 0.0:
+                log_sf = np.log1p(-0.5 * np.exp(upper))
+            else:
+                log_sf = np.log(0.5 * np.exp(-upper))
+
+            total += (2.0 * i + 1.0) / n * (log_cdf + log_sf)
+
+        return -n - total
+
     @override
     def execute_statistic(self, rvs, **kwargs):
         """Execute the Anderson--Darling statistic for a Laplace distribution.
@@ -186,10 +213,22 @@ class AndersonDarlingLaplaceGofStatistic(AbstractLaplaceGofStatistic, ADStatisti
         :param rvs: observations assumed to follow a Laplace distribution.
         :return: Anderson--Darling A^2 statistic computed from log-CDF values.
         """
-        sorted_rvs = np.sort(np.asarray(rvs))
-        log_cdf = scipy_stats.laplace.logcdf(sorted_rvs, loc=self.t, scale=self.s)
-        log_sf = scipy_stats.laplace.logsf(sorted_rvs, loc=self.t, scale=self.s)
-        return ADStatistic.do_execute_statistic(self, sorted_rvs, log_cdf=log_cdf, log_sf=log_sf)
+        sorted_rvs = np.sort(np.asarray(rvs, dtype=np.float64))
+        return self.do_execute_statistic(sorted_rvs)
+
+    def do_execute_statistic(self, sorted_rvs):
+        """Calculate the statistic for an already sorted sample.
+
+        :param sorted_rvs: one-dimensional sample sorted in ascending order.
+        :return: Anderson--Darling statistic computed from Laplace log probabilities.
+        """
+        return float(
+            self._calculate_statistic(
+                sorted_rvs,
+                self.t,
+                self.s,
+            )
+        )
 
 
 class KuiperLaplaceGofStatistic(AbstractLaplaceGofStatistic):

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -1,4 +1,6 @@
+import numpy as np
 import pytest
+import scipy.stats as scipy_stats
 
 from pysatl_criterion import DistributionType
 from pysatl_criterion.statistics.goodness_of_fit.laplace import (
@@ -102,6 +104,46 @@ def test_anderson_darling_laplace_statistic():
     result = statistic.execute_statistic(_SAMPLE)
 
     assert result == pytest.approx(1.0445557661164182)
+
+
+@pytest.mark.parametrize(
+    ("sample", "location", "scale"),
+    [
+        ([0.1], 0.0, 1.0),
+        ([2.0, -1.0, 0.5, 0.5], 0.0, 1.0),
+        ([-5.0, -2.0, 3.0, 8.0], 1.0, 2.5),
+        (np.array([1, -2, 3, 0], dtype=np.int64), -0.5, 1.5),
+        ([-1_000.0, -100.0, 0.0, 100.0, 1_000.0], 0.0, 1.0),
+        ([], 0.0, 1.0),
+    ],
+)
+def test_anderson_darling_laplace_matches_scipy_reference(sample, location, scale):
+    """Optimized Anderson--Darling implementation should match SciPy."""
+    sorted_sample = np.sort(np.asarray(sample, dtype=np.float64))
+    n = len(sorted_sample)
+
+    if n == 0:
+        expected = 0.0
+    else:
+        log_cdf = scipy_stats.laplace.logcdf(
+            sorted_sample,
+            loc=location,
+            scale=scale,
+        )
+        log_sf = scipy_stats.laplace.logsf(
+            sorted_sample,
+            loc=location,
+            scale=scale,
+        )
+        i = np.arange(1, n + 1)
+        expected = -n - np.sum((2 * i - 1.0) / n * (log_cdf + log_sf[::-1]))
+
+    result = AndersonDarlingLaplaceGofStatistic(
+        t=location,
+        s=scale,
+    ).execute_statistic(sample)
+
+    assert result == pytest.approx(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Optimized the Anderson–Darling Laplace statistic using Numba.

## Changes

- Added Numba as a project dependency
- Moved the statistic calculation into a private static method
- Added JIT compilation with `@njit`
- Kept sample sorting outside the compiled method
- Added tests comparing the result with the SciPy implementation
- Added a benchmark for the original and optimized implementations

## Benchmark

- Sample size: 10,000
- Calls: 1,000
- Speedup: 3.48x

Part of #122