### PR TITLE
refactor: extract shared benchmark runner

### DIFF
--- a/benchmarks/benchmark_anderson_darling_laplace.py
+++ b/benchmarks/benchmark_anderson_darling_laplace.py
@@ -1,8 +1,6 @@
-import time
-from collections.abc import Callable
-
 import numpy as np
 import scipy.stats as scipy_stats
+from benchmark_runner import BenchmarkRunner
 
 from pysatl_criterion.statistics.goodness_of_fit.laplace import AndersonDarlingLaplaceGofStatistic
 
@@ -24,16 +22,6 @@ def anderson_darling_laplace_reference(
     )
     i = np.arange(1, n + 1)
     return float(-n - np.sum((2 * i - 1.0) / n * (log_cdf + log_sf[::-1])))
-
-
-def measure(function: Callable[[], float], calls: int) -> float:
-    """Measure total execution time for the requested number of calls."""
-    start = time.perf_counter()
-
-    for _ in range(calls):
-        function()
-
-    return time.perf_counter() - start
 
 
 def main() -> None:
@@ -59,32 +47,19 @@ def main() -> None:
         scale,
     )
     np.testing.assert_allclose(optimized_result, reference_result)
+    runner = BenchmarkRunner(calls)
 
-    reference_elapsed = measure(
-        lambda: anderson_darling_laplace_reference(
+    runner.run_comparison(
+        sample_size=sample.size,
+        reference_name="SciPy reference implementation",
+        reference_function=lambda: anderson_darling_laplace_reference(
             sorted_sample,
             location,
             scale,
         ),
-        calls,
+        optimized_name="Numba implementation",
+        optimized_function=lambda: statistic.do_execute_statistic(sorted_sample),
     )
-    optimized_elapsed = measure(
-        lambda: statistic.do_execute_statistic(sorted_sample),
-        calls,
-    )
-
-    print(f"Sample size: {sample.size}")
-    print(f"Calls: {calls}")
-    print()
-    print("SciPy reference implementation:")
-    print(f"Total time: {reference_elapsed:.6f} seconds")
-    print(f"Average time per call: {reference_elapsed / calls:.9f} seconds")
-    print()
-    print("Numba implementation:")
-    print(f"Total time: {optimized_elapsed:.6f} seconds")
-    print(f"Average time per call: {optimized_elapsed / calls:.9f} seconds")
-    print()
-    print(f"Speedup: {reference_elapsed / optimized_elapsed:.2f}x")
 
 
 if __name__ == "__main__":

--- a/benchmarks/benchmark_greenwood_laplace.py
+++ b/benchmarks/benchmark_greenwood_laplace.py
@@ -1,8 +1,6 @@
-import time
-from collections.abc import Callable
-
 import numpy as np
 import scipy.stats as scipy_stats
+from benchmark_runner import BenchmarkRunner
 
 from pysatl_criterion.statistics.goodness_of_fit.laplace import GreenwoodLaplaceGofStatistic
 
@@ -32,20 +30,6 @@ def greenwood_laplace_reference(
     return float(np.sum(spacings**2))
 
 
-def measure(
-    function: Callable[[], float],
-    calls: int,
-) -> float:
-    """Measure total execution time for the requested number of calls."""
-
-    start = time.perf_counter()
-
-    for _ in range(calls):
-        function()
-
-    return time.perf_counter() - start
-
-
 def main() -> None:
     location = 0.0
     scale = 1.0
@@ -64,35 +48,19 @@ def main() -> None:
     )
 
     statistic.do_execute_statistic(sorted_sample)
+    runner = BenchmarkRunner(calls)
 
-    reference_elapsed = measure(
-        lambda: greenwood_laplace_reference(
+    runner.run_comparison(
+        sample_size=sample.size,
+        reference_name="SciPy reference implementation",
+        reference_function=lambda: greenwood_laplace_reference(
             sorted_sample,
             location,
             scale,
         ),
-        calls,
+        optimized_name="Numba implementation",
+        optimized_function=lambda: statistic.do_execute_statistic(sorted_sample),
     )
-
-    optimized_elapsed = measure(
-        lambda: statistic.do_execute_statistic(sorted_sample),
-        calls,
-    )
-
-    speedup = reference_elapsed / optimized_elapsed
-
-    print(f"Sample size: {sample.size}")
-    print(f"Calls: {calls}")
-    print()
-    print("SciPy reference implementation:")
-    print(f"Total time: {reference_elapsed:.6f} seconds")
-    print(f"Average time per call: {reference_elapsed / calls:.9f} seconds")
-    print()
-    print("Numba implementation:")
-    print(f"Total time: {optimized_elapsed:.6f} seconds")
-    print(f"Average time per call: {optimized_elapsed / calls:.9f} seconds")
-    print()
-    print(f"Speedup: {speedup:.2f}x")
 
 
 if __name__ == "__main__":

--- a/benchmarks/benchmark_runner.py
+++ b/benchmarks/benchmark_runner.py
@@ -1,0 +1,70 @@
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Store the timing result for one benchmarked implementation."""
+
+    name: str
+    total_time: float
+    calls: int
+
+    @property
+    def average_time(self) -> float:
+        """Return the average execution time per call."""
+        return self.total_time / self.calls
+
+
+class BenchmarkRunner:
+    """Measure and report execution times for two implementations."""
+
+    def __init__(self, calls: int) -> None:
+        if calls <= 0:
+            raise ValueError("Number of calls must be positive.")
+
+        self.calls = calls
+
+    def measure(self, name: str, function: Callable[[], object]) -> BenchmarkResult:
+        """Measure a function for the configured number of calls."""
+        start = time.perf_counter()
+
+        for _ in range(self.calls):
+            function()
+
+        return BenchmarkResult(
+            name=name,
+            total_time=time.perf_counter() - start,
+            calls=self.calls,
+        )
+
+    def run_comparison(
+        self,
+        *,
+        sample_size: int,
+        reference_name: str,
+        reference_function: Callable[[], object],
+        optimized_name: str,
+        optimized_function: Callable[[], object],
+    ) -> tuple[BenchmarkResult, BenchmarkResult]:
+        """Measure two implementations and print their comparison."""
+        reference_result = self.measure(reference_name, reference_function)
+        optimized_result = self.measure(optimized_name, optimized_function)
+
+        print(f"Sample size: {sample_size}")
+        print(f"Calls: {self.calls}")
+        print()
+        self._print_result(reference_result)
+        print()
+        self._print_result(optimized_result)
+        print()
+        print(f"Speedup: {reference_result.total_time / optimized_result.total_time:.2f}x")
+
+        return reference_result, optimized_result
+
+    @staticmethod
+    def _print_result(result: BenchmarkResult) -> None:
+        print(f"{result.name}:")
+        print(f"Total time: {result.total_time:.6f} seconds")
+        print(f"Average time per call: {result.average_time:.9f} seconds")

--- a/benchmarks/benchmark_stein_uniform.py
+++ b/benchmarks/benchmark_stein_uniform.py
@@ -1,7 +1,5 @@
-import time
-from collections.abc import Callable
-
 import numpy as np
+from benchmark_runner import BenchmarkRunner
 
 from pysatl_criterion.statistics.goodness_of_fit.uniform import SteinUniformGofStatistic
 
@@ -25,16 +23,6 @@ def stein_uniform_reference(sample: np.ndarray) -> float:
     return float(2 * total / (n * (n - 1)))
 
 
-def measure(function: Callable[[], float], calls: int) -> float:
-    """Measure total execution time for the requested number of calls."""
-    start = time.perf_counter()
-
-    for _ in range(calls):
-        function()
-
-    return time.perf_counter() - start
-
-
 def main() -> None:
     sample_size = 100
     calls = 1_000
@@ -43,29 +31,15 @@ def main() -> None:
 
     # Compile the Numba kernel before measuring execution time.
     statistic.do_execute_statistic(sample)
+    runner = BenchmarkRunner(calls)
 
-    reference_elapsed = measure(
-        lambda: stein_uniform_reference(sample),
-        calls,
+    runner.run_comparison(
+        sample_size=sample.size,
+        reference_name="Python reference implementation",
+        reference_function=lambda: stein_uniform_reference(sample),
+        optimized_name="Numba implementation",
+        optimized_function=lambda: statistic.do_execute_statistic(sample),
     )
-    optimized_elapsed = measure(
-        lambda: statistic.do_execute_statistic(sample),
-        calls,
-    )
-    speedup = reference_elapsed / optimized_elapsed
-
-    print(f"Sample size: {sample.size}")
-    print(f"Calls: {calls}")
-    print()
-    print("Python reference implementation:")
-    print(f"Total time: {reference_elapsed:.6f} seconds")
-    print(f"Average time per call: {reference_elapsed / calls:.9f} seconds")
-    print()
-    print("Numba implementation:")
-    print(f"Total time: {optimized_elapsed:.6f} seconds")
-    print(f"Average time per call: {optimized_elapsed / calls:.9f} seconds")
-    print()
-    print(f"Speedup: {speedup:.2f}x")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extracted the repeated benchmark logic into a shared `BenchmarkRunner` class

## Changes

- Added a shared class for measuring execution time
- Added common calculation and output for average time and speedup
- Updated Greenwood, Anderson–Darling, and Stein benchmarks to use the shared runner
- Kept sample preparation, sorting, and Numba warm-up inside each criterion benchmark