### PR TITLE
perf: optimize Cramer-von Mises Laplace statistic with Numba

### DIFF
--- a/benchmarks/benchmark_cramer_von_mises_laplace.py
+++ b/benchmarks/benchmark_cramer_von_mises_laplace.py
@@ -2,54 +2,51 @@ import numpy as np
 import scipy.stats as scipy_stats
 from benchmark_runner import BenchmarkRunner
 
-from pysatl_criterion.statistics.goodness_of_fit.laplace import GreenwoodLaplaceGofStatistic
+from pysatl_criterion.statistics.goodness_of_fit.laplace import CramerVonMisesLaplaceGofStatistic
 
 
-def greenwood_laplace_reference(sorted_sample: np.ndarray, location: float, scale: float) -> float:
-    """Calculate the Greenwood statistic using the original SciPy approach."""
-
+def cramer_von_mises_laplace_reference(
+    sorted_sample: np.ndarray, location: float, scale: float
+) -> float:
+    """Calculate the Cramer--von Mises statistic using the original approach."""
+    n = len(sorted_sample)
     cdf_values = scipy_stats.laplace.cdf(
         sorted_sample,
         loc=location,
         scale=scale,
     )
-    spacings = np.diff(
-        np.concatenate(
-            (
-                [0.0],
-                cdf_values,
-                [1.0],
-            )
-        )
-    )
-
-    return float(np.sum(spacings**2))
+    expected_cdf = (2 * np.arange(1, n + 1) - 1) / (2 * n)
+    return float(1 / (12 * n) + np.sum((expected_cdf - cdf_values) ** 2))
 
 
 def main() -> None:
     location = 0.0
     scale = 1.0
     calls = 1_000
-
     sample = np.random.default_rng(42).laplace(
         loc=location,
         scale=scale,
         size=10_000,
     )
     sorted_sample = np.sort(sample)
-
-    statistic = GreenwoodLaplaceGofStatistic(
+    statistic = CramerVonMisesLaplaceGofStatistic(
         t=location,
         s=scale,
     )
 
-    statistic.do_execute_statistic(sorted_sample)
+    optimized_result = statistic.do_execute_statistic(sorted_sample)
+    reference_result = cramer_von_mises_laplace_reference(
+        sorted_sample,
+        location,
+        scale,
+    )
+    np.testing.assert_allclose(optimized_result, reference_result)
     runner = BenchmarkRunner(calls)
 
     runner.run_comparison(
         sample_size=sample.size,
         reference_name="SciPy reference implementation",
-        reference_function=lambda: greenwood_laplace_reference(
+        reference_function=lambda: cramer_von_mises_laplace_reference(
             sorted_sample,
             location,
             scale,

--- a/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
@@ -142,6 +142,28 @@ class CramerVonMisesLaplaceGofStatistic(AbstractLaplaceGofStatistic, CrammerVonM
         short_code = CramerVonMisesLaplaceGofStatistic.short_code()
         return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
 
+    @staticmethod
+    @njit
+    def _calculate_statistic(
+        sorted_rvs: np.ndarray, t: float, s: float
+    ) -> float:  # pragma: no cover
+        n = len(sorted_rvs)
+        total = 1.0 / (12.0 * n)
+
+        for i in range(n):
+            x = sorted_rvs[i]
+
+            if x < t:
+                current_cdf = 0.5 * np.exp((x - t) / s)
+            else:
+                current_cdf = 1.0 - 0.5 * np.exp(-(x - t) / s)
+
+            expected_cdf = (2.0 * i + 1.0) / (2.0 * n)
+            difference = expected_cdf - current_cdf
+            total += difference * difference
+
+        return total
+
     @override
     def execute_statistic(self, rvs, **kwargs):
         """Execute the Cramer--von Mises statistic for a Laplace distribution.
@@ -149,9 +171,22 @@ class CramerVonMisesLaplaceGofStatistic(AbstractLaplaceGofStatistic, CrammerVonM
         :param rvs: observations assumed to follow a Laplace distribution.
         :return: Cramer--von Mises W^2 statistic computed with the Laplace CDF.
         """
-        sorted_rvs = np.sort(np.asarray(rvs))
-        cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
-        return CrammerVonMisesStatistic.do_execute_statistic(self, sorted_rvs, cdf_vals)
+        sorted_rvs = np.sort(np.asarray(rvs, dtype=np.float64))
+        return self.do_execute_statistic(sorted_rvs)
+
+    def do_execute_statistic(self, sorted_rvs):
+        """Calculate the statistic for an already sorted sample.
+
+        :param sorted_rvs: one-dimensional sample sorted in ascending order.
+        :return: Cramer--von Mises statistic computed from the Laplace CDF.
+        """
+        return float(
+            self._calculate_statistic(
+                sorted_rvs,
+                self.t,
+                self.s,
+            )
+        )
 
 
 class AndersonDarlingLaplaceGofStatistic(AbstractLaplaceGofStatistic, ADStatistic):

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -94,6 +94,42 @@ def test_cramer_von_mises_laplace_statistic():
     assert result == pytest.approx(0.2225993471193351)
 
 
+@pytest.mark.parametrize(
+    ("sample", "location", "scale"),
+    [
+        ([0.1], 0.0, 1.0),
+        ([2.0, -1.0, 0.5, 0.5], 0.0, 1.0),
+        ([-5.0, -2.0, 3.0, 8.0], 1.0, 2.5),
+        (np.array([1, -2, 3, 0], dtype=np.int64), -0.5, 1.5),
+        ([-1_000.0, -100.0, 0.0, 100.0, 1_000.0], 0.0, 1.0),
+    ],
+)
+def test_cramer_von_mises_laplace_matches_scipy_reference(sample, location, scale):
+    """Optimized Cramer--von Mises implementation should match SciPy."""
+    sorted_sample = np.sort(np.asarray(sample, dtype=np.float64))
+    n = len(sorted_sample)
+    cdf_values = scipy_stats.laplace.cdf(
+        sorted_sample,
+        loc=location,
+        scale=scale,
+    )
+    expected_cdf = (2 * np.arange(1, n + 1) - 1) / (2 * n)
+    expected = 1 / (12 * n) + np.sum((expected_cdf - cdf_values) ** 2)
+
+    result = CramerVonMisesLaplaceGofStatistic(
+        t=location,
+        s=scale,
+    ).execute_statistic(sample)
+
+    assert result == pytest.approx(expected)
+
+
+def test_cramer_von_mises_laplace_rejects_empty_sample():
+    """Keep the existing error for an empty sample."""
+    with pytest.raises(ZeroDivisionError):
+        CramerVonMisesLaplaceGofStatistic().execute_statistic([])
+
+
 def test_anderson_darling_laplace_statistic():
     """Verify the Anderson--Darling statistic for a Laplace sample."""
 


### PR DESCRIPTION
## Summary

Optimized the Cramer–von Mises Laplace statistic using Numba.

Part of #122

## Changes

- Moved the statistic calculation into a private static method
- Added JIT compilation with `@njit`
- Calculated the Laplace CDF directly inside the compiled loop
- Avoided unnecessary intermediate NumPy arrays
- Kept sample sorting outside the compiled method
- Added tests comparing the result with the SciPy implementation
- Added a benchmark using the shared `BenchmarkRunner`

## Benchmark

- Sample size: 10,000
- Calls: 1,000
- Speedup: approximately 4.77x