### PR TITLE
perf: optimize Kuiper Laplace statistic with Numba

### DIFF
--- a/benchmarks/benchmark_kuiper_laplace.py
+++ b/benchmarks/benchmark_kuiper_laplace.py
@@ -1,0 +1,63 @@
+import numpy as np
+import scipy.stats as scipy_stats
+from benchmark_runner import BenchmarkRunner
+
+from pysatl_criterion.statistics.goodness_of_fit.laplace import KuiperLaplaceGofStatistic
+
+
+def kuiper_laplace_reference(sorted_sample: np.ndarray, location: float, scale: float) -> float:
+    """Calculate the Kuiper statistic using the original SciPy approach."""
+    n = len(sorted_sample)
+    cdf_values = scipy_stats.laplace.cdf(
+        sorted_sample,
+        loc=location,
+        scale=scale,
+    )
+    indices = np.arange(1, n + 1)
+    d_plus = np.max(indices / n - cdf_values)
+    d_minus = np.max(cdf_values - (indices - 1) / n)
+
+    return float(d_plus + d_minus)
+
+
+def main() -> None:
+    location = 0.0
+    scale = 1.0
+    calls = 1_000
+
+    sample = np.random.default_rng(42).laplace(
+        loc=location,
+        scale=scale,
+        size=10_000,
+    )
+    sorted_sample = np.sort(sample)
+
+    statistic = KuiperLaplaceGofStatistic(
+        t=location,
+        s=scale,
+    )
+
+    optimized_result = statistic.do_execute_statistic(sorted_sample)
+    reference_result = kuiper_laplace_reference(
+        sorted_sample,
+        location,
+        scale,
+    )
+    np.testing.assert_allclose(optimized_result, reference_result)
+    runner = BenchmarkRunner(calls)
+
+    runner.run_comparison(
+        sample_size=sample.size,
+        reference_name="SciPy reference implementation",
+        reference_function=lambda: kuiper_laplace_reference(
+            sorted_sample,
+            location,
+            scale,
+        ),
+        optimized_name="Numba implementation",
+        optimized_function=lambda: statistic.do_execute_statistic(sorted_sample),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
@@ -264,6 +264,33 @@ class KuiperLaplaceGofStatistic(AbstractLaplaceGofStatistic):
         short_code = KuiperLaplaceGofStatistic.short_code()
         return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
 
+    @staticmethod
+    @njit
+    def _calculate_statistic(
+        sorted_rvs: np.ndarray,
+        t: float,
+        s: float,
+    ) -> float:  # pragma: no cover
+        n = len(sorted_rvs)
+        d_plus = 0.0
+        d_minus = 0.0
+
+        for i in range(n):
+            x = sorted_rvs[i]
+
+            if x < t:
+                current_cdf = 0.5 * np.exp((x - t) / s)
+            else:
+                current_cdf = 1.0 - 0.5 * np.exp(-(x - t) / s)
+
+            if np.isnan(current_cdf):
+                return np.nan
+
+            d_plus = max(d_plus, (i + 1.0) / n - current_cdf)
+            d_minus = max(d_minus, current_cdf - i / n)
+
+        return d_plus + d_minus
+
     @override
     def execute_statistic(self, rvs):
         """
@@ -273,21 +300,27 @@ class KuiperLaplaceGofStatistic(AbstractLaplaceGofStatistic):
         :raises ValueError: if the sample is empty.
         """
 
-        sorted_rvs = np.sort(np.asarray(rvs))
-        n = len(sorted_rvs)
-
-        if n == 0:
+        sorted_rvs = np.sort(np.asarray(rvs, dtype=np.float64))
+        if len(sorted_rvs) == 0:
             raise ValueError(
                 "At least one observation is required to compute the Kuiper statistic."
             )
+        return self.do_execute_statistic(sorted_rvs)
 
-        cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
+    def do_execute_statistic(self, sorted_rvs):
+        """
+        Calculate the statistic for an already sorted sample.
 
-        i = np.arange(1, n + 1)
-        d_plus = np.max(i / n - cdf_vals)
-        d_minus = np.max(cdf_vals - (i - 1) / n)
-
-        return float(d_plus + d_minus)
+        :param sorted_rvs: one-dimensional sample sorted in ascending order.
+        :return: Kuiper statistic computed from the Laplace CDF.
+        """
+        return float(
+            self._calculate_statistic(
+                sorted_rvs,
+                self.t,
+                self.s,
+            )
+        )
 
 
 class WatsonLaplaceGofStatistic(AbstractLaplaceGofStatistic):

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -148,6 +148,85 @@ def test_anderson_darling_laplace_matches_scipy_reference(sample, location, scal
 
 
 @pytest.mark.parametrize(
+    ("sample", "location", "scale"),
+    [
+        ([0.1], 0.0, 1.0),
+        ([2.0, -1.0, 0.5, 0.5], 0.0, 1.0),
+        ([-5.0, -2.0, 3.0, 8.0], 1.0, 2.5),
+        (np.array([1, -2, 3, 0], dtype=np.int64), -0.5, 1.5),
+        ([-1_000.0, -100.0, 0.0, 100.0, 1_000.0], 0.0, 1.0),
+    ],
+)
+def test_kuiper_laplace_matches_scipy_reference(sample, location, scale):
+    """Optimized Kuiper implementation should match the SciPy reference."""
+    sorted_sample = np.sort(np.asarray(sample, dtype=np.float64))
+    n = len(sorted_sample)
+
+    cdf_values = scipy_stats.laplace.cdf(
+        sorted_sample,
+        loc=location,
+        scale=scale,
+    )
+    indices = np.arange(1, n + 1)
+    d_plus = np.max(indices / n - cdf_values)
+    d_minus = np.max(cdf_values - (indices - 1) / n)
+    expected = d_plus + d_minus
+
+    result = KuiperLaplaceGofStatistic(
+        t=location,
+        s=scale,
+    ).execute_statistic(sample)
+
+    assert result == pytest.approx(expected)
+
+
+def test_kuiper_laplace_preserves_nan():
+    """Kuiper statistic should preserve NaN from the original implementation."""
+    result = KuiperLaplaceGofStatistic().execute_statistic([0.0, np.nan, 1.0])
+
+    assert np.isnan(result)
+
+
+@pytest.mark.parametrize(
+    ("sample", "location", "scale"),
+    [
+        ([0.1], 0.0, 1.0),
+        ([2.0, -1.0, 0.5, 0.5], 0.0, 1.0),
+        ([-5.0, -2.0, 3.0, 8.0], 1.0, 2.5),
+        (np.array([1, -2, 3, 0], dtype=np.int64), -0.5, 1.5),
+    ],
+)
+def test_greenwood_laplace_matches_scipy_reference(sample, location, scale):
+    """Optimized Greenwood implementation should match the SciPy reference."""
+
+    sorted_sample = np.sort(np.asarray(sample, dtype=np.float64))
+    cdf_values = scipy_stats.laplace.cdf(
+        sorted_sample,
+        loc=location,
+        scale=scale,
+    )
+    spacings = np.diff(
+        np.concatenate(
+            (
+                [0.0],
+                cdf_values,
+                [1.0],
+            )
+        )
+    )
+    expected = np.sum(spacings**2)
+
+    statistic = GreenwoodLaplaceGofStatistic(
+        t=location,
+        s=scale,
+    )
+
+    result = statistic.execute_statistic(sample)
+
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
     ("statistic_class", "expected_value"),
     [
         (KolmogorovSmirnovLaplaceGofStatistic, 0.10023112481762697),
@@ -248,42 +327,3 @@ def test_additional_laplace_statistics_require_non_empty_sample(statistic_class)
 
     with pytest.raises(ValueError, match="At least one observation is required"):
         statistic_class(t=_LOCATION, s=_SCALE).execute_statistic([])
-
-
-@pytest.mark.parametrize(
-    ("sample", "location", "scale"),
-    [
-        ([0.1], 0.0, 1.0),
-        ([2.0, -1.0, 0.5, 0.5], 0.0, 1.0),
-        ([-5.0, -2.0, 3.0, 8.0], 1.0, 2.5),
-        (np.array([1, -2, 3, 0], dtype=np.int64), -0.5, 1.5),
-    ],
-)
-def test_greenwood_laplace_matches_scipy_reference(sample, location, scale):
-    """Optimized Greenwood implementation should match the SciPy reference."""
-
-    sorted_sample = np.sort(np.asarray(sample, dtype=np.float64))
-    cdf_values = scipy_stats.laplace.cdf(
-        sorted_sample,
-        loc=location,
-        scale=scale,
-    )
-    spacings = np.diff(
-        np.concatenate(
-            (
-                [0.0],
-                cdf_values,
-                [1.0],
-            )
-        )
-    )
-    expected = np.sum(spacings**2)
-
-    statistic = GreenwoodLaplaceGofStatistic(
-        t=location,
-        s=scale,
-    )
-
-    result = statistic.execute_statistic(sample)
-
-    assert result == pytest.approx(expected)

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -288,6 +288,11 @@ def test_greenwood_laplace_alternative():
     assert isinstance(GreenwoodLaplaceGofStatistic().alternative(), RightAlternative)
 
 
+def test_kuiper_laplace_alternative():
+    """Ensure Kuiper uses a right-tailed alternative."""
+    assert isinstance(KuiperLaplaceGofStatistic().alternative(), RightAlternative)
+
+
 def test_laplace_distribution_type():
     """Ensure Laplace statistics report the Laplace distribution type."""
 


### PR DESCRIPTION
## Summary

Optimized the Kuiper Laplace statistic using Numba.

Part of #122.

## Changes

- Moved the Kuiper statistic calculation into a private static method
- Added JIT compilation with `@njit`
- Calculated the Laplace CDF directly inside the compiled loop
- Replaced intermediate NumPy arrays with scalar calculations
- Kept input conversion and sorting outside the compiled method
- Preserved the existing behavior for empty samples and `NaN` values
- Added parameterized tests comparing the optimized result with an independent SciPy-based reference
- Added a benchmark using the shared `BenchmarkRunner`
- Warmed up the Numba method before benchmark timing

## Benchmark

- Sample size: 10,000
- Calls: 1,000
- SciPy: approximately 0.000122167 seconds per call
- Numba: approximately 0.000025932 seconds per call
- Speedup: approximately 4.71x