### PR TITLE
perf: optimize Watson Laplace statistic with Numba

### DIFF
--- a/benchmarks/benchmark_watson_laplace.py
+++ b/benchmarks/benchmark_watson_laplace.py
@@ -1,0 +1,68 @@
+import numpy as np
+import scipy.stats as scipy_stats
+from benchmark_runner import BenchmarkRunner
+
+from pysatl_criterion.statistics.goodness_of_fit.laplace import WatsonLaplaceGofStatistic
+
+
+def watson_laplace_reference(
+    sorted_sample: np.ndarray,
+    location: float,
+    scale: float,
+) -> float:
+    """Calculate the Watson statistic using the original SciPy approach."""
+    n = len(sorted_sample)
+    cdf_values = scipy_stats.laplace.cdf(
+        sorted_sample,
+        loc=location,
+        scale=scale,
+    )
+    expected_cdf = (2 * np.arange(1, n + 1) - 1) / (2 * n)
+    differences = cdf_values - expected_cdf
+
+    w_squared = 1.0 / (12 * n) + np.sum(differences**2)
+    mean_adjustment = np.sum(cdf_values) - n / 2
+
+    return float(w_squared - mean_adjustment**2 / n)
+
+
+def main() -> None:
+    location = 0.0
+    scale = 1.0
+    calls = 1_000
+    sample = np.random.default_rng(42).laplace(
+        loc=location,
+        scale=scale,
+        size=10_000,
+    )
+    sorted_sample = np.sort(sample)
+    statistic = WatsonLaplaceGofStatistic(
+        t=location,
+        s=scale,
+    )
+
+    # Compile the Numba kernel before measuring execution time.
+    optimized_result = statistic.do_execute_statistic(sorted_sample)
+    reference_result = watson_laplace_reference(
+        sorted_sample,
+        location,
+        scale,
+    )
+    np.testing.assert_allclose(optimized_result, reference_result)
+    runner = BenchmarkRunner(calls)
+
+    runner.run_comparison(
+        sample_size=sample.size,
+        reference_name="SciPy reference implementation",
+        reference_function=lambda: watson_laplace_reference(
+            sorted_sample,
+            location,
+            scale,
+        ),
+        optimized_name="Numba implementation",
+        optimized_function=lambda: statistic.do_execute_statistic(sorted_sample),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/laplace.py
@@ -322,6 +322,33 @@ class WatsonLaplaceGofStatistic(AbstractLaplaceGofStatistic):
         short_code = WatsonLaplaceGofStatistic.short_code()
         return f"{short_code}_{AbstractLaplaceGofStatistic.code()}"
 
+    @staticmethod
+    @njit
+    def _calculate_statistic(
+        sorted_rvs: np.ndarray,
+        t: float,
+        s: float,
+    ) -> float:  # pragma: no cover
+        n = len(sorted_rvs)
+        total = 1.0 / (12.0 * n)
+        cdf_sum = 0.0
+
+        for i in range(n):
+            x = sorted_rvs[i]
+
+            if x < t:
+                current_cdf = 0.5 * np.exp((x - t) / s)
+            else:
+                current_cdf = 1.0 - 0.5 * np.exp(-(x - t) / s)
+
+            expected_cdf = (2.0 * i + 1.0) / (2.0 * n)
+            difference = current_cdf - expected_cdf
+            total += difference * difference
+            cdf_sum += current_cdf
+
+        mean_adjustment = cdf_sum - n / 2.0
+        return total - mean_adjustment * mean_adjustment / n
+
     @override
     def execute_statistic(self, rvs):
         """
@@ -332,19 +359,29 @@ class WatsonLaplaceGofStatistic(AbstractLaplaceGofStatistic):
         :raises ValueError: if sample is empty.
         """
 
-        sorted_rvs = np.sort(np.asarray(rvs))
+        sorted_rvs = np.sort(np.asarray(rvs, dtype=np.float64))
         n = len(sorted_rvs)
         if n == 0:
             raise ValueError(
                 "At least one observation is required to compute the Watson statistic."
             )
 
-        cdf_vals = scipy_stats.laplace.cdf(sorted_rvs, loc=self.t, scale=self.s)
-        u = (2 * np.arange(1, n + 1) - 1) / (2 * n)
-        diff = cdf_vals - u
-        w_squared = 1.0 / (12 * n) + np.sum(diff**2)
-        mean_adj = np.sum(cdf_vals) - n / 2
-        return float(w_squared - (mean_adj**2) / n)
+        return self.do_execute_statistic(sorted_rvs)
+
+    def do_execute_statistic(self, sorted_rvs):
+        """
+        Calculate the Watson statistic for an already sorted sample.
+
+        :param sorted_rvs: one-dimensional sample sorted in ascending order.
+        :return: Watson statistic computed from the Laplace CDF values.
+        """
+        return float(
+            self._calculate_statistic(
+                sorted_rvs,
+                self.t,
+                self.s,
+            )
+        )
 
 
 class GreenwoodLaplaceGofStatistic(AbstractLaplaceGofStatistic):

--- a/tests/distributions/test_laplace.py
+++ b/tests/distributions/test_laplace.py
@@ -148,6 +148,41 @@ def test_anderson_darling_laplace_matches_scipy_reference(sample, location, scal
 
 
 @pytest.mark.parametrize(
+    ("sample", "location", "scale"),
+    [
+        ([0.1], 0.0, 1.0),
+        ([2.0, -1.0, 0.5, 0.5], 0.0, 1.0),
+        ([-5.0, -2.0, 3.0, 8.0], 1.0, 2.5),
+        (np.array([1, -2, 3, 0], dtype=np.int64), -0.5, 1.5),
+        ([-1_000.0, -100.0, 0.0, 100.0, 1_000.0], 0.0, 1.0),
+    ],
+)
+def test_watson_laplace_matches_scipy_reference(sample, location, scale):
+    """Optimized Watson implementation should match the SciPy reference."""
+    sorted_sample = np.sort(np.asarray(sample, dtype=np.float64))
+    n = len(sorted_sample)
+
+    cdf_values = scipy_stats.laplace.cdf(
+        sorted_sample,
+        loc=location,
+        scale=scale,
+    )
+    expected_cdf = (2 * np.arange(1, n + 1) - 1) / (2 * n)
+    differences = cdf_values - expected_cdf
+
+    w_squared = 1.0 / (12 * n) + np.sum(differences**2)
+    mean_adjustment = np.sum(cdf_values) - n / 2
+    expected = w_squared - mean_adjustment**2 / n
+
+    result = WatsonLaplaceGofStatistic(
+        t=location,
+        s=scale,
+    ).execute_statistic(sample)
+
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
     ("statistic_class", "expected_value"),
     [
         (KolmogorovSmirnovLaplaceGofStatistic, 0.10023112481762697),
@@ -207,6 +242,11 @@ def test_greenwood_laplace_alternative():
     """Ensure Greenwood uses a right-tailed alternative."""
 
     assert isinstance(GreenwoodLaplaceGofStatistic().alternative(), RightAlternative)
+
+
+def test_watson_laplace_alternative():
+    """Ensure Watson uses a right-tailed alternative."""
+    assert isinstance(WatsonLaplaceGofStatistic().alternative(), RightAlternative)
 
 
 def test_laplace_distribution_type():


### PR DESCRIPTION
## Summary

Optimized the Watson Laplace statistic using Numba.

Part of #122.

## Changes

- Moved the Watson statistic calculation into a private static method
- Added JIT compilation with `@njit`
- Calculated the Laplace CDF directly inside the compiled loop
- Replaced intermediate NumPy arrays with scalar calculations
- Calculated the squared deviations and CDF sum in a single pass
- Kept input conversion and sorting outside the compiled method
- Preserved the existing empty-sample behavior
- Added parameterized tests against an independent SciPy-based reference
- Added coverage for the Watson right-tailed alternative
- Added a benchmark using the shared `BenchmarkRunner`
- Warmed up the Numba method before benchmark timing

## Benchmark

- Sample size: 10,000
- Calls: 1,000
- SciPy: approximately 0.000121222 seconds per call
- Numba: approximately 0.000024334 seconds per call
- Speedup: approximately 4.98x