### PR TITLE
feat: add Numba-optimized hyperbolic GoF statistics

### DIFF
--- a/benchmarks/benchmark_anderson_darling_hyperbolic.py
+++ b/benchmarks/benchmark_anderson_darling_hyperbolic.py
@@ -1,0 +1,57 @@
+import numpy as np
+from benchmark_runner import BenchmarkRunner
+from hyperbolic_benchmark_utils import (
+    ALPHA,
+    BETA,
+    CALLS,
+    DELTA,
+    MU,
+    SAMPLE_SIZE,
+    create_sorted_sample,
+    log_probabilities,
+)
+
+from pysatl_criterion.statistics.goodness_of_fit.hyperbolic import (
+    AndersonDarlingHyperbolicGofStatistic,
+)
+
+
+def reference(log_cdf: np.ndarray, log_sf: np.ndarray) -> float:
+    """Calculate the statistic using vectorized NumPy operations."""
+    n = len(log_cdf)
+    weights = (2.0 * np.arange(n) + 1.0) / n
+    return float(-n - np.sum(weights * (log_cdf + log_sf[::-1])))
+
+
+def main() -> None:
+    """Compare the NumPy and Numba statistic kernels."""
+    sorted_sample = create_sorted_sample()
+    log_cdf, log_sf = log_probabilities(sorted_sample)
+    statistic = AndersonDarlingHyperbolicGofStatistic(
+        alpha=ALPHA,
+        beta=BETA,
+        delta=DELTA,
+        mu=MU,
+    )
+    optimized_result = statistic.do_execute_statistic(
+        sorted_sample,
+        log_cdf=log_cdf,
+        log_sf=log_sf,
+    )
+    np.testing.assert_allclose(optimized_result, reference(log_cdf, log_sf))
+
+    BenchmarkRunner(CALLS).run_comparison(
+        sample_size=SAMPLE_SIZE,
+        reference_name="NumPy reference statistic kernel",
+        reference_function=lambda: reference(log_cdf, log_sf),
+        optimized_name="Numba statistic kernel",
+        optimized_function=lambda: statistic.do_execute_statistic(
+            sorted_sample,
+            log_cdf=log_cdf,
+            log_sf=log_sf,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_cramer_von_mises_hyperbolic.py
+++ b/benchmarks/benchmark_cramer_von_mises_hyperbolic.py
@@ -1,0 +1,49 @@
+import numpy as np
+from benchmark_runner import BenchmarkRunner
+from hyperbolic_benchmark_utils import (
+    ALPHA,
+    BETA,
+    CALLS,
+    DELTA,
+    MU,
+    SAMPLE_SIZE,
+    cdf_values,
+    create_sorted_sample,
+)
+
+from pysatl_criterion.statistics.goodness_of_fit.hyperbolic import (
+    CramerVonMisesHyperbolicGofStatistic,
+)
+
+
+def reference(cdf: np.ndarray) -> float:
+    """Calculate the statistic using vectorized NumPy operations."""
+    n = len(cdf)
+    expected = (2.0 * np.arange(n) + 1.0) / (2.0 * n)
+    return float(1.0 / (12.0 * n) + np.sum((expected - cdf) ** 2))
+
+
+def main() -> None:
+    """Compare the NumPy and Numba statistic kernels."""
+    sorted_sample = create_sorted_sample()
+    cdf = cdf_values(sorted_sample)
+    statistic = CramerVonMisesHyperbolicGofStatistic(
+        alpha=ALPHA,
+        beta=BETA,
+        delta=DELTA,
+        mu=MU,
+    )
+    optimized_result = statistic.do_execute_statistic(sorted_sample, cdf)
+    np.testing.assert_allclose(optimized_result, reference(cdf))
+
+    BenchmarkRunner(CALLS).run_comparison(
+        sample_size=SAMPLE_SIZE,
+        reference_name="NumPy reference statistic kernel",
+        reference_function=lambda: reference(cdf),
+        optimized_name="Numba statistic kernel",
+        optimized_function=lambda: statistic.do_execute_statistic(sorted_sample, cdf),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_kolmogorov_smirnov_hyperbolic.py
+++ b/benchmarks/benchmark_kolmogorov_smirnov_hyperbolic.py
@@ -1,0 +1,51 @@
+import numpy as np
+from benchmark_runner import BenchmarkRunner
+from hyperbolic_benchmark_utils import (
+    ALPHA,
+    BETA,
+    CALLS,
+    DELTA,
+    MU,
+    SAMPLE_SIZE,
+    cdf_values,
+    create_sorted_sample,
+)
+
+from pysatl_criterion.statistics.goodness_of_fit.hyperbolic import (
+    KolmogorovSmirnovHyperbolicGofStatistic,
+)
+
+
+def reference(cdf: np.ndarray) -> float:
+    """Calculate the two-sided statistic using vectorized NumPy operations."""
+    n = len(cdf)
+    positions = np.arange(n, dtype=np.float64)
+    d_plus = np.max((positions + 1.0) / n - cdf)
+    d_minus = np.max(cdf - positions / n)
+    return float(max(d_plus, d_minus))
+
+
+def main() -> None:
+    """Compare the NumPy and Numba statistic kernels."""
+    sorted_sample = create_sorted_sample()
+    cdf = cdf_values(sorted_sample)
+    statistic = KolmogorovSmirnovHyperbolicGofStatistic(
+        alpha=ALPHA,
+        beta=BETA,
+        delta=DELTA,
+        mu=MU,
+    )
+    optimized_result = statistic.do_execute_statistic(sorted_sample, cdf)
+    np.testing.assert_allclose(optimized_result, reference(cdf))
+
+    BenchmarkRunner(CALLS).run_comparison(
+        sample_size=SAMPLE_SIZE,
+        reference_name="NumPy reference statistic kernel",
+        reference_function=lambda: reference(cdf),
+        optimized_name="Numba statistic kernel",
+        optimized_function=lambda: statistic.do_execute_statistic(sorted_sample, cdf),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_kuiper_hyperbolic.py
+++ b/benchmarks/benchmark_kuiper_hyperbolic.py
@@ -1,0 +1,48 @@
+import numpy as np
+from benchmark_runner import BenchmarkRunner
+from hyperbolic_benchmark_utils import (
+    ALPHA,
+    BETA,
+    CALLS,
+    DELTA,
+    MU,
+    SAMPLE_SIZE,
+    cdf_values,
+    create_sorted_sample,
+)
+
+from pysatl_criterion.statistics.goodness_of_fit.hyperbolic import KuiperHyperbolicGofStatistic
+
+
+def reference(cdf: np.ndarray) -> float:
+    """Calculate the statistic using vectorized NumPy operations."""
+    n = len(cdf)
+    positions = np.arange(n, dtype=np.float64)
+    d_plus = np.max((positions + 1.0) / n - cdf)
+    d_minus = np.max(cdf - positions / n)
+    return float(d_plus + d_minus)
+
+
+def main() -> None:
+    """Compare the NumPy and Numba statistic kernels."""
+    cdf = cdf_values(create_sorted_sample())
+    statistic = KuiperHyperbolicGofStatistic(
+        alpha=ALPHA,
+        beta=BETA,
+        delta=DELTA,
+        mu=MU,
+    )
+    optimized_result = statistic.do_execute_statistic(cdf)
+    np.testing.assert_allclose(optimized_result, reference(cdf))
+
+    BenchmarkRunner(CALLS).run_comparison(
+        sample_size=SAMPLE_SIZE,
+        reference_name="NumPy reference statistic kernel",
+        reference_function=lambda: reference(cdf),
+        optimized_name="Numba statistic kernel",
+        optimized_function=lambda: statistic.do_execute_statistic(cdf),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_watson_hyperbolic.py
+++ b/benchmarks/benchmark_watson_hyperbolic.py
@@ -1,0 +1,47 @@
+import numpy as np
+from benchmark_runner import BenchmarkRunner
+from hyperbolic_benchmark_utils import (
+    ALPHA,
+    BETA,
+    CALLS,
+    DELTA,
+    MU,
+    SAMPLE_SIZE,
+    cdf_values,
+    create_sorted_sample,
+)
+
+from pysatl_criterion.statistics.goodness_of_fit.hyperbolic import WatsonHyperbolicGofStatistic
+
+
+def reference(cdf: np.ndarray) -> float:
+    """Calculate the statistic using vectorized NumPy operations."""
+    n = len(cdf)
+    expected = (2.0 * np.arange(n) + 1.0) / (2.0 * n)
+    cvm = 1.0 / (12.0 * n) + np.sum((expected - cdf) ** 2)
+    return float(cvm - n * (np.mean(cdf) - 0.5) ** 2)
+
+
+def main() -> None:
+    """Compare the NumPy and Numba statistic kernels."""
+    cdf = cdf_values(create_sorted_sample())
+    statistic = WatsonHyperbolicGofStatistic(
+        alpha=ALPHA,
+        beta=BETA,
+        delta=DELTA,
+        mu=MU,
+    )
+    optimized_result = statistic.do_execute_statistic(cdf)
+    np.testing.assert_allclose(optimized_result, reference(cdf))
+
+    BenchmarkRunner(CALLS).run_comparison(
+        sample_size=SAMPLE_SIZE,
+        reference_name="NumPy reference statistic kernel",
+        reference_function=lambda: reference(cdf),
+        optimized_name="Numba statistic kernel",
+        optimized_function=lambda: statistic.do_execute_statistic(cdf),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hyperbolic_benchmark_utils.py
+++ b/benchmarks/hyperbolic_benchmark_utils.py
@@ -1,0 +1,54 @@
+import numpy as np
+import scipy.stats as scipy_stats
+
+
+ALPHA = 1.5
+BETA = 0.25
+DELTA = 1.0
+MU = 0.0
+CALLS = 1_000
+SAMPLE_SIZE = 10_000
+
+
+def create_sorted_sample() -> np.ndarray:
+    """Generate one reproducible sorted hyperbolic sample."""
+    sample = scipy_stats.genhyperbolic.rvs(
+        p=1.0,
+        a=ALPHA * DELTA,
+        b=BETA * DELTA,
+        loc=MU,
+        scale=DELTA,
+        size=SAMPLE_SIZE,
+        random_state=np.random.default_rng(42),
+    )
+    return np.sort(np.asarray(sample, dtype=np.float64))
+
+
+def cdf_values(sorted_sample: np.ndarray) -> np.ndarray:
+    """Calculate reference CDF values outside the timed statistic kernels."""
+    values = scipy_stats.genhyperbolic.cdf(
+        sorted_sample,
+        p=1.0,
+        a=ALPHA * DELTA,
+        b=BETA * DELTA,
+        loc=MU,
+        scale=DELTA,
+    )
+    return np.asarray(values, dtype=np.float64)
+
+
+def log_probabilities(sorted_sample: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Calculate stable tail probabilities outside the timed AD kernels."""
+    parameters = {
+        "p": 1.0,
+        "a": ALPHA * DELTA,
+        "b": BETA * DELTA,
+        "loc": MU,
+        "scale": DELTA,
+    }
+    log_cdf = scipy_stats.genhyperbolic.logcdf(sorted_sample, **parameters)
+    log_sf = scipy_stats.genhyperbolic.logsf(sorted_sample, **parameters)
+    return (
+        np.asarray(log_cdf, dtype=np.float64),
+        np.asarray(log_sf, dtype=np.float64),
+    )

--- a/src/pysatl_criterion/distribution/distribution_type.py
+++ b/src/pysatl_criterion/distribution/distribution_type.py
@@ -58,6 +58,7 @@ class DistributionType(Enum):
     FISHER = "fisher"
     RAYLEIGH = "rayleigh"
     PARETO = "pareto"
+    HYPERBOLIC = "hyperbolic"
 
     def __new__(cls, value: str):
         """

--- a/src/pysatl_criterion/distribution/distributions.py
+++ b/src/pysatl_criterion/distribution/distributions.py
@@ -446,6 +446,35 @@ class LaplaceDistributionDescriptor(DistributionDescriptor):
         ]
 
 
+class HyperbolicDistributionDescriptor(DistributionDescriptor):
+    """Descriptor for the hyperbolic distribution."""
+
+    @staticmethod
+    def type() -> DistributionType:
+        """Return the hyperbolic distribution type.
+
+        :return: hyperbolic distribution enum member.
+        """
+        return DistributionType.HYPERBOLIC
+
+    @staticmethod
+    def parameters() -> list[DistributionParameterDescriptor]:
+        """Return parameters for the hyperbolic distribution.
+
+        :return: descriptors for shape, skewness, scale, and location.
+        """
+        return [
+            DistributionParameterDescriptor(
+                "α", "alpha", "Shape. α > 0 and |β| < α", 1, PositiveNumberValidator()
+            ),
+            DistributionParameterDescriptor("β", "beta", "Skewness. |β| < α", 0),
+            DistributionParameterDescriptor(
+                "δ", "delta", "Scale. δ > 0", 1, PositiveNumberValidator()
+            ),
+            DistributionParameterDescriptor("μ", "mu", "Location", 0),
+        ]
+
+
 class LoConNormDistributionDescriptor(DistributionDescriptor):
     """
     Descriptor for the location-contaminated normal distribution.

--- a/src/pysatl_criterion/statistics/goodness_of_fit/__init__.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/__init__.py
@@ -88,6 +88,14 @@ from pysatl_criterion.statistics.goodness_of_fit.graph_goodness_of_fit import (
     GraphIndependenceNumberTestStatistic,
     GraphMaxDegreeTestStatistic,
 )
+from pysatl_criterion.statistics.goodness_of_fit.hyperbolic import (
+    AbstractHyperbolicGofStatistic,
+    AndersonDarlingHyperbolicGofStatistic,
+    CramerVonMisesHyperbolicGofStatistic,
+    KolmogorovSmirnovHyperbolicGofStatistic,
+    KuiperHyperbolicGofStatistic,
+    WatsonHyperbolicGofStatistic,
+)
 from pysatl_criterion.statistics.goodness_of_fit.laplace import (
     AbstractLaplaceGofStatistic,
     AndersonDarlingLaplaceGofStatistic,
@@ -253,6 +261,13 @@ from pysatl_criterion.statistics.goodness_of_fit.weibull import (
 
 
 __all__ = [
+    # Hyperbolic distribution statistics
+    "AbstractHyperbolicGofStatistic",
+    "AndersonDarlingHyperbolicGofStatistic",
+    "CramerVonMisesHyperbolicGofStatistic",
+    "KolmogorovSmirnovHyperbolicGofStatistic",
+    "KuiperHyperbolicGofStatistic",
+    "WatsonHyperbolicGofStatistic",
     # Base and Models
     "AbstractGraphTestStatistic",
     # Common Aliases

--- a/src/pysatl_criterion/statistics/goodness_of_fit/hyperbolic.py
+++ b/src/pysatl_criterion/statistics/goodness_of_fit/hyperbolic.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+from abc import ABC
+
+import numpy as np
+import scipy.stats as scipy_stats
+from numba import njit
+from typing_extensions import override
+
+from pysatl_criterion import DistributionType
+from pysatl_criterion.statistics import AbstractGoodnessOfFitStatistic
+from pysatl_criterion.statistics.alternative import Alternative, AlternativeType, RightAlternative
+from pysatl_criterion.statistics.goodness_of_fit.common import (
+    ADStatistic,
+    CrammerVonMisesStatistic,
+    KSStatistic,
+)
+from pysatl_criterion.statistics.hypothesis import GoodnessOfFitHypothesis
+
+
+class AbstractHyperbolicGofStatistic(AbstractGoodnessOfFitStatistic, ABC):
+    """Base class for hyperbolic distribution goodness-of-fit statistics.
+
+    The classical hyperbolic distribution is the generalized hyperbolic
+    distribution with tail parameter ``p = 1``. The parameterization follows
+    Barndorff-Nielsen (1978), *Hyperbolic Distributions and Distributions on
+    Hyperbolae*, Scandinavian Journal of Statistics, 5(3), 151--157.
+    """
+
+    def __init__(
+        self,
+        alpha: float = 1.0,
+        beta: float = 0.0,
+        delta: float = 1.0,
+        mu: float = 0.0,
+    ) -> None:
+        """Initialize a hyperbolic goodness-of-fit statistic.
+
+        :param alpha: positive shape parameter satisfying ``|beta| < alpha``.
+        :param beta: skewness parameter satisfying ``|beta| < alpha``.
+        :param delta: positive scale parameter.
+        :param mu: location parameter.
+        :raises ValueError: if any parameter is non-finite or violates its constraint.
+        """
+        if not np.isfinite(alpha) or alpha <= 0:
+            raise ValueError("Alpha must be finite and positive.")
+        if not np.isfinite(beta) or abs(beta) >= alpha:
+            raise ValueError("Beta must be finite and satisfy abs(beta) < alpha.")
+        if not np.isfinite(delta) or delta <= 0:
+            raise ValueError("Delta must be finite and positive.")
+        if not np.isfinite(mu):
+            raise ValueError("Mu must be finite.")
+
+        self.alpha = float(alpha)
+        self.beta = float(beta)
+        self.delta = float(delta)
+        self.mu = float(mu)
+
+    @override
+    def hypothesis(self) -> GoodnessOfFitHypothesis:
+        """Return the parameters of the reference hyperbolic distribution.
+
+        :return: hypothesis containing ``alpha``, ``beta``, ``delta``, and ``mu``.
+        """
+        return GoodnessOfFitHypothesis(
+            {
+                "alpha": self.alpha,
+                "beta": self.beta,
+                "delta": self.delta,
+                "mu": self.mu,
+            }
+        )
+
+    @staticmethod
+    @override
+    def distribution() -> DistributionType:
+        """Return the hyperbolic distribution type.
+
+        :return: hyperbolic distribution enum member.
+        """
+        return DistributionType.HYPERBOLIC
+
+    @staticmethod
+    @override
+    def code() -> str:
+        """Return the base identifier for hyperbolic statistics.
+
+        :return: ``HYPERBOLIC_GOODNESS_OF_FIT``.
+        """
+        return f"HYPERBOLIC_{AbstractGoodnessOfFitStatistic.code()}"
+
+    @staticmethod
+    def _prepare_sample(rvs) -> np.ndarray:
+        """Convert, validate, and sort a sample.
+
+        :param rvs: one-dimensional observations.
+        :return: sorted ``float64`` NumPy array.
+        :raises ValueError: if the sample is not one-dimensional or is empty.
+        """
+        sample = np.asarray(rvs, dtype=np.float64)
+        if sample.ndim != 1:
+            raise ValueError("Sample must be one-dimensional.")
+        if sample.size == 0:
+            raise ValueError("Sample must contain at least one observation.")
+        return np.sort(sample)
+
+    def _cdf(self, sorted_rvs: np.ndarray) -> np.ndarray:
+        """Evaluate the hyperbolic CDF for a sorted sample.
+
+        :param sorted_rvs: sample sorted in ascending order.
+        :return: CDF values in sample order.
+        """
+        return np.asarray(
+            scipy_stats.genhyperbolic.cdf(
+                sorted_rvs,
+                p=1.0,
+                a=self.alpha * self.delta,
+                b=self.beta * self.delta,
+                loc=self.mu,
+                scale=self.delta,
+            ),
+            dtype=np.float64,
+        )
+
+    def _log_probabilities(self, sorted_rvs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Evaluate stable log-CDF and log-survival probabilities.
+
+        :param sorted_rvs: sample sorted in ascending order.
+        :return: pair containing log-CDF and log-survival arrays.
+        """
+        parameters = {
+            "p": 1.0,
+            "a": self.alpha * self.delta,
+            "b": self.beta * self.delta,
+            "loc": self.mu,
+            "scale": self.delta,
+        }
+        log_cdf = scipy_stats.genhyperbolic.logcdf(sorted_rvs, **parameters)
+        log_sf = scipy_stats.genhyperbolic.logsf(sorted_rvs, **parameters)
+        return (
+            np.asarray(log_cdf, dtype=np.float64),
+            np.asarray(log_sf, dtype=np.float64),
+        )
+
+
+class KolmogorovSmirnovHyperbolicGofStatistic(AbstractHyperbolicGofStatistic, KSStatistic):
+    """Kolmogorov--Smirnov EDF statistic for a hyperbolic distribution.
+
+    The statistic is the largest signed or two-sided deviation between the
+    empirical and reference CDFs. See Kolmogorov (1933), *Sulla determinazione
+    empirica di una legge di distribuzione*.
+    """
+
+    def __init__(
+        self,
+        alternative_type: AlternativeType = AlternativeType.TWO_TAILED,
+        mode: str = "auto",
+        alpha: float = 1.0,
+        beta: float = 0.0,
+        delta: float = 1.0,
+        mu: float = 0.0,
+    ) -> None:
+        """Initialize the Kolmogorov--Smirnov statistic.
+
+        :param alternative_type: left, right, or two-sided alternative.
+        :param mode: calculation mode retained for compatibility with ``KSStatistic``.
+        :param alpha: positive shape parameter satisfying ``|beta| < alpha``.
+        :param beta: skewness parameter satisfying ``|beta| < alpha``.
+        :param delta: positive scale parameter.
+        :param mu: location parameter.
+        """
+        AbstractHyperbolicGofStatistic.__init__(self, alpha, beta, delta, mu)
+        KSStatistic.__init__(self, alternative_type=alternative_type, mode=mode)
+
+    @staticmethod
+    @override
+    def short_code() -> str:
+        """Return the short statistic identifier.
+
+        :return: ``KS``.
+        """
+        return "KS"
+
+    @staticmethod
+    @override
+    def code() -> str:
+        """Return the unique statistic identifier.
+
+        :return: ``KS_HYPERBOLIC_GOODNESS_OF_FIT``.
+        """
+        short_code = KolmogorovSmirnovHyperbolicGofStatistic.short_code()
+        return f"{short_code}_{AbstractHyperbolicGofStatistic.code()}"
+
+    @staticmethod
+    @njit
+    def _calculate_statistic(
+        cdf_values: np.ndarray,
+        alternative_code: int,
+    ) -> float:  # pragma: no cover
+        n = len(cdf_values)
+        d_plus = 0.0
+        d_minus = 0.0
+
+        for i in range(n):
+            current_cdf = cdf_values[i]
+            if np.isnan(current_cdf):
+                return np.nan
+            d_plus = max(d_plus, (i + 1.0) / n - current_cdf)
+            d_minus = max(d_minus, current_cdf - i / n)
+
+        if alternative_code > 0:
+            return d_plus
+        if alternative_code < 0:
+            return d_minus
+        return max(d_plus, d_minus)
+
+    @override
+    def execute_statistic(self, rvs, **kwargs) -> float:
+        """Calculate the Kolmogorov--Smirnov statistic.
+
+        :param rvs: one-dimensional sample.
+        :return: selected one- or two-sided KS statistic.
+        """
+        sorted_rvs = self._prepare_sample(rvs)
+        return self.do_execute_statistic(sorted_rvs, self._cdf(sorted_rvs))
+
+    def do_execute_statistic(self, rvs, cdf_vals=None) -> float:
+        """Calculate the statistic from precomputed CDF values.
+
+        :param rvs: sample sorted in ascending order.
+        :param cdf_vals: reference CDF values in sorted sample order.
+        :return: selected KS statistic.
+        :raises ValueError: if CDF values are not provided.
+        """
+        if cdf_vals is None:
+            raise ValueError("CDF values are required.")
+        alternative_codes = {
+            AlternativeType.TWO_TAILED: 0,
+            AlternativeType.RIGHT: 1,
+            AlternativeType.LEFT: -1,
+        }
+        alternative_code = alternative_codes[self.alternative_type]
+        return float(self._calculate_statistic(cdf_vals, alternative_code))
+
+
+class CramerVonMisesHyperbolicGofStatistic(
+    AbstractHyperbolicGofStatistic, CrammerVonMisesStatistic
+):
+    """Cramer--von Mises EDF statistic for a hyperbolic distribution.
+
+    The statistic integrates the squared difference between empirical and
+    reference CDFs. See Cramér (1928), *On the composition of elementary errors*.
+    """
+
+    @staticmethod
+    @override
+    def short_code() -> str:
+        """Return the short statistic identifier.
+
+        :return: ``CVM``.
+        """
+        return "CVM"
+
+    @staticmethod
+    @override
+    def code() -> str:
+        """Return the unique statistic identifier.
+
+        :return: ``CVM_HYPERBOLIC_GOODNESS_OF_FIT``.
+        """
+        short_code = CramerVonMisesHyperbolicGofStatistic.short_code()
+        return f"{short_code}_{AbstractHyperbolicGofStatistic.code()}"
+
+    @staticmethod
+    @njit
+    def _calculate_statistic(cdf_values: np.ndarray) -> float:  # pragma: no cover
+        n = len(cdf_values)
+        total = 1.0 / (12.0 * n)
+
+        for i in range(n):
+            expected_cdf = (2.0 * i + 1.0) / (2.0 * n)
+            difference = expected_cdf - cdf_values[i]
+            total += difference * difference
+
+        return total
+
+    @override
+    def execute_statistic(self, rvs, **kwargs) -> float:
+        """Calculate the Cramer--von Mises statistic.
+
+        :param rvs: one-dimensional sample.
+        :return: Cramer--von Mises statistic.
+        """
+        sorted_rvs = self._prepare_sample(rvs)
+        return self.do_execute_statistic(sorted_rvs, self._cdf(sorted_rvs))
+
+    def do_execute_statistic(self, rvs, cdf_vals) -> float:
+        """Calculate the statistic from precomputed CDF values.
+
+        :param rvs: sample sorted in ascending order.
+        :param cdf_vals: reference CDF values in sorted sample order.
+        :return: Cramer--von Mises statistic.
+        """
+        return float(self._calculate_statistic(cdf_vals))
+
+
+class AndersonDarlingHyperbolicGofStatistic(AbstractHyperbolicGofStatistic, ADStatistic):
+    """Anderson--Darling EDF statistic for a hyperbolic distribution.
+
+    Tail differences receive more weight than in the Cramer--von Mises test.
+    See Anderson and Darling (1952), *Asymptotic theory of certain goodness of
+    fit criteria based on stochastic processes*, Annals of Mathematical Statistics.
+    """
+
+    @staticmethod
+    @override
+    def short_code() -> str:
+        """Return the short statistic identifier.
+
+        :return: ``AD``.
+        """
+        return "AD"
+
+    @staticmethod
+    @override
+    def code() -> str:
+        """Return the unique statistic identifier.
+
+        :return: ``AD_HYPERBOLIC_GOODNESS_OF_FIT``.
+        """
+        short_code = AndersonDarlingHyperbolicGofStatistic.short_code()
+        return f"{short_code}_{AbstractHyperbolicGofStatistic.code()}"
+
+    @staticmethod
+    @njit
+    def _calculate_statistic(
+        log_cdf: np.ndarray,
+        log_sf: np.ndarray,
+    ) -> float:  # pragma: no cover
+        n = len(log_cdf)
+        total = 0.0
+
+        for i in range(n):
+            total += (2.0 * i + 1.0) / n * (log_cdf[i] + log_sf[n - i - 1])
+
+        return -n - total
+
+    @override
+    def execute_statistic(self, rvs, **kwargs) -> float:
+        """Calculate the Anderson--Darling statistic.
+
+        :param rvs: one-dimensional sample.
+        :return: Anderson--Darling statistic.
+        """
+        sorted_rvs = self._prepare_sample(rvs)
+        log_cdf, log_sf = self._log_probabilities(sorted_rvs)
+        return self.do_execute_statistic(sorted_rvs, log_cdf=log_cdf, log_sf=log_sf)
+
+    def do_execute_statistic(self, rvs, log_cdf=None, log_sf=None) -> float:
+        """Calculate the statistic from stable log probabilities.
+
+        :param rvs: sample sorted in ascending order.
+        :param log_cdf: log-CDF values in sorted sample order.
+        :param log_sf: log-survival values in sorted sample order.
+        :return: Anderson--Darling statistic.
+        :raises ValueError: if either log-probability array is not provided.
+        """
+        if log_cdf is None or log_sf is None:
+            raise ValueError("Log-CDF and log-survival values are required.")
+        return float(self._calculate_statistic(log_cdf, log_sf))
+
+
+class KuiperHyperbolicGofStatistic(AbstractHyperbolicGofStatistic):
+    """Kuiper EDF statistic for a hyperbolic distribution.
+
+    The statistic adds the largest positive and negative EDF deviations. See
+    Kuiper (1960), *Tests concerning random points on a circle*.
+    """
+
+    @override
+    def alternative(self) -> Alternative:
+        """Return the right-tailed alternative used for the statistic.
+
+        :return: right-tailed alternative.
+        """
+        return RightAlternative()
+
+    @staticmethod
+    @override
+    def short_code() -> str:
+        """Return the short statistic identifier.
+
+        :return: ``KUI``.
+        """
+        return "KUI"
+
+    @staticmethod
+    @override
+    def code() -> str:
+        """Return the unique statistic identifier.
+
+        :return: ``KUI_HYPERBOLIC_GOODNESS_OF_FIT``.
+        """
+        short_code = KuiperHyperbolicGofStatistic.short_code()
+        return f"{short_code}_{AbstractHyperbolicGofStatistic.code()}"
+
+    @staticmethod
+    @njit
+    def _calculate_statistic(cdf_values: np.ndarray) -> float:  # pragma: no cover
+        n = len(cdf_values)
+        d_plus = 0.0
+        d_minus = 0.0
+
+        for i in range(n):
+            current_cdf = cdf_values[i]
+            if np.isnan(current_cdf):
+                return np.nan
+            d_plus = max(d_plus, (i + 1.0) / n - current_cdf)
+            d_minus = max(d_minus, current_cdf - i / n)
+
+        return d_plus + d_minus
+
+    @override
+    def execute_statistic(self, rvs, **kwargs) -> float:
+        """Calculate the Kuiper statistic.
+
+        :param rvs: one-dimensional sample.
+        :return: Kuiper statistic ``D+ + D-``.
+        """
+        sorted_rvs = self._prepare_sample(rvs)
+        return self.do_execute_statistic(self._cdf(sorted_rvs))
+
+    def do_execute_statistic(self, cdf_values: np.ndarray) -> float:
+        """Calculate the statistic from precomputed CDF values.
+
+        :param cdf_values: reference CDF values in sorted sample order.
+        :return: Kuiper statistic.
+        """
+        return float(self._calculate_statistic(cdf_values))
+
+
+class WatsonHyperbolicGofStatistic(AbstractHyperbolicGofStatistic):
+    """Watson centered Cramer--von Mises statistic for a hyperbolic distribution.
+
+    The squared mean probability deviation is removed from the Cramer--von
+    Mises statistic. See Watson (1961), *Goodness-of-fit tests on a circle*.
+    """
+
+    @override
+    def alternative(self) -> Alternative:
+        """Return the right-tailed alternative used for the statistic.
+
+        :return: right-tailed alternative.
+        """
+        return RightAlternative()
+
+    @staticmethod
+    @override
+    def short_code() -> str:
+        """Return the short statistic identifier.
+
+        :return: ``WAT``.
+        """
+        return "WAT"
+
+    @staticmethod
+    @override
+    def code() -> str:
+        """Return the unique statistic identifier.
+
+        :return: ``WAT_HYPERBOLIC_GOODNESS_OF_FIT``.
+        """
+        short_code = WatsonHyperbolicGofStatistic.short_code()
+        return f"{short_code}_{AbstractHyperbolicGofStatistic.code()}"
+
+    @staticmethod
+    @njit
+    def _calculate_statistic(cdf_values: np.ndarray) -> float:  # pragma: no cover
+        n = len(cdf_values)
+        total = 1.0 / (12.0 * n)
+        cdf_sum = 0.0
+
+        for i in range(n):
+            current_cdf = cdf_values[i]
+            expected_cdf = (2.0 * i + 1.0) / (2.0 * n)
+            difference = current_cdf - expected_cdf
+            total += difference * difference
+            cdf_sum += current_cdf
+
+        mean_adjustment = cdf_sum - n / 2.0
+        return total - mean_adjustment * mean_adjustment / n
+
+    @override
+    def execute_statistic(self, rvs, **kwargs) -> float:
+        """Calculate the Watson statistic.
+
+        :param rvs: one-dimensional sample.
+        :return: Watson ``U²`` statistic.
+        """
+        sorted_rvs = self._prepare_sample(rvs)
+        return self.do_execute_statistic(self._cdf(sorted_rvs))
+
+    def do_execute_statistic(self, cdf_values: np.ndarray) -> float:
+        """Calculate the statistic from precomputed CDF values.
+
+        :param cdf_values: reference CDF values in sorted sample order.
+        :return: Watson statistic.
+        """
+        return float(self._calculate_statistic(cdf_values))

--- a/tests/distributions/test_hyperbolic.py
+++ b/tests/distributions/test_hyperbolic.py
@@ -1,0 +1,279 @@
+from collections import Counter
+
+import numpy as np
+import pytest
+import scipy.stats as scipy_stats
+
+from pysatl_criterion import DistributionType
+from pysatl_criterion.distribution.distributions import HyperbolicDistributionDescriptor
+from pysatl_criterion.statistics.alternative import (
+    AlternativeType,
+    LeftAlternative,
+    RightAlternative,
+    TwoSidedAlternative,
+)
+from pysatl_criterion.statistics.goodness_of_fit.hyperbolic import (
+    AbstractHyperbolicGofStatistic,
+    AndersonDarlingHyperbolicGofStatistic,
+    CramerVonMisesHyperbolicGofStatistic,
+    KolmogorovSmirnovHyperbolicGofStatistic,
+    KuiperHyperbolicGofStatistic,
+    WatsonHyperbolicGofStatistic,
+)
+from pysatl_criterion.utils.distribution import get_available_distribution_descriptor
+from pysatl_criterion.utils.statistic import get_available_criteria_codes
+
+
+_SAMPLE = np.array([-2.4, 1.3, -0.2, 0.0, 2.1, -1.0, 0.7], dtype=np.float64)
+
+
+def _distribution_parameters(
+    alpha: float,
+    beta: float,
+    delta: float,
+    mu: float,
+) -> dict[str, float]:
+    """Translate the classical hyperbolic parameters to SciPy parameters."""
+    return {
+        "p": 1.0,
+        "a": alpha * delta,
+        "b": beta * delta,
+        "loc": mu,
+        "scale": delta,
+    }
+
+
+def _cdf_values(
+    sample,
+    alpha: float,
+    beta: float,
+    delta: float,
+    mu: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return a sorted sample and its SciPy hyperbolic CDF values."""
+    sorted_sample = np.sort(np.asarray(sample, dtype=np.float64))
+    cdf_values = scipy_stats.genhyperbolic.cdf(
+        sorted_sample,
+        **_distribution_parameters(alpha, beta, delta, mu),
+    )
+    return sorted_sample, np.asarray(cdf_values, dtype=np.float64)
+
+
+def test_hyperbolic_base_metadata():
+    """The base class should expose stable distribution metadata."""
+    statistic = CramerVonMisesHyperbolicGofStatistic(
+        alpha=1.5,
+        beta=0.25,
+        delta=2.0,
+        mu=-0.5,
+    )
+
+    assert AbstractHyperbolicGofStatistic.code() == "HYPERBOLIC_GOODNESS_OF_FIT"
+    assert statistic.distribution() == DistributionType.HYPERBOLIC
+    assert statistic.hypothesis().params == {
+        "alpha": 1.5,
+        "beta": 0.25,
+        "delta": 2.0,
+        "mu": -0.5,
+    }
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"alpha": 0.0}, "Alpha must be finite and positive"),
+        ({"alpha": np.inf}, "Alpha must be finite and positive"),
+        ({"alpha": 1.0, "beta": 1.0}, r"abs\(beta\) < alpha"),
+        ({"alpha": 1.0, "beta": -1.0}, r"abs\(beta\) < alpha"),
+        ({"beta": np.nan}, "Beta must be finite"),
+        ({"delta": 0.0}, "Delta must be finite and positive"),
+        ({"delta": np.inf}, "Delta must be finite and positive"),
+        ({"mu": np.nan}, "Mu must be finite"),
+    ],
+)
+def test_hyperbolic_parameter_validation(kwargs, message):
+    """Invalid hyperbolic parameters should be rejected."""
+    with pytest.raises(ValueError, match=message):
+        CramerVonMisesHyperbolicGofStatistic(**kwargs)
+
+
+@pytest.mark.parametrize("sample", [[], np.ones((2, 2))])
+def test_hyperbolic_sample_validation(sample):
+    """Statistics should require a non-empty one-dimensional sample."""
+    with pytest.raises(ValueError):
+        CramerVonMisesHyperbolicGofStatistic().execute_statistic(sample)
+
+
+@pytest.mark.parametrize(
+    ("sample", "alpha", "beta", "delta", "mu"),
+    [
+        (_SAMPLE, 1.5, 0.25, 1.0, 0.0),
+        ([3, -2, 1, 1, 0], 2.0, -0.5, 0.75, 1.0),
+        ([-8.0, -2.0, 0.0, 5.0, 12.0], 0.8, 0.2, 2.5, -1.5),
+    ],
+)
+def test_hyperbolic_edf_statistics_match_scipy_reference(
+    sample,
+    alpha,
+    beta,
+    delta,
+    mu,
+):
+    """Numba statistic kernels should match independent NumPy/SciPy formulas."""
+    sorted_sample, cdf_values = _cdf_values(sample, alpha, beta, delta, mu)
+    n = len(sorted_sample)
+    positions = np.arange(n, dtype=np.float64)
+    expected_cdf = (2.0 * positions + 1.0) / (2.0 * n)
+    d_plus = np.max((positions + 1.0) / n - cdf_values)
+    d_minus = np.max(cdf_values - positions / n)
+    expected_cvm = 1.0 / (12.0 * n) + np.sum((expected_cdf - cdf_values) ** 2)
+    expected_kuiper = d_plus + d_minus
+    expected_watson = expected_cvm - n * (np.mean(cdf_values) - 0.5) ** 2
+
+    parameters = {
+        "alpha": alpha,
+        "beta": beta,
+        "delta": delta,
+        "mu": mu,
+    }
+
+    assert KolmogorovSmirnovHyperbolicGofStatistic(**parameters).execute_statistic(
+        sample
+    ) == pytest.approx(max(d_plus, d_minus))
+    assert CramerVonMisesHyperbolicGofStatistic(**parameters).execute_statistic(
+        sample
+    ) == pytest.approx(expected_cvm)
+    assert KuiperHyperbolicGofStatistic(**parameters).execute_statistic(sample) == pytest.approx(
+        expected_kuiper
+    )
+    assert WatsonHyperbolicGofStatistic(**parameters).execute_statistic(sample) == pytest.approx(
+        expected_watson
+    )
+
+
+@pytest.mark.parametrize(
+    ("alpha", "beta", "delta", "mu"),
+    [
+        (1.5, 0.25, 1.0, 0.0),
+        (2.0, -0.5, 0.75, 1.0),
+    ],
+)
+def test_anderson_darling_hyperbolic_matches_scipy_reference(alpha, beta, delta, mu):
+    """Anderson--Darling should use stable SciPy tail probabilities."""
+    sorted_sample = np.sort(_SAMPLE)
+    parameters = _distribution_parameters(alpha, beta, delta, mu)
+    log_cdf = scipy_stats.genhyperbolic.logcdf(sorted_sample, **parameters)
+    log_sf = scipy_stats.genhyperbolic.logsf(sorted_sample, **parameters)
+    n = len(sorted_sample)
+    weights = (2.0 * np.arange(n) + 1.0) / n
+    expected = -n - np.sum(weights * (log_cdf + log_sf[::-1]))
+
+    result = AndersonDarlingHyperbolicGofStatistic(
+        alpha=alpha,
+        beta=beta,
+        delta=delta,
+        mu=mu,
+    ).execute_statistic(_SAMPLE)
+
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("alternative_type", "alternative_class", "expected_side"),
+    [
+        (AlternativeType.TWO_TAILED, TwoSidedAlternative, "two-sided"),
+        (AlternativeType.RIGHT, RightAlternative, "right"),
+        (AlternativeType.LEFT, LeftAlternative, "left"),
+    ],
+)
+def test_kolmogorov_smirnov_hyperbolic_alternatives(
+    alternative_type,
+    alternative_class,
+    expected_side,
+):
+    """KS should calculate the deviation selected by its alternative."""
+    _, cdf_values = _cdf_values(_SAMPLE, 1.5, 0.25, 1.0, 0.0)
+    n = len(cdf_values)
+    positions = np.arange(n, dtype=np.float64)
+    d_plus = np.max((positions + 1.0) / n - cdf_values)
+    d_minus = np.max(cdf_values - positions / n)
+    expected = {
+        "two-sided": max(d_plus, d_minus),
+        "right": d_plus,
+        "left": d_minus,
+    }[expected_side]
+    statistic = KolmogorovSmirnovHyperbolicGofStatistic(
+        alternative_type=alternative_type,
+        alpha=1.5,
+        beta=0.25,
+    )
+
+    assert isinstance(statistic.alternative(), alternative_class)
+    assert statistic.execute_statistic(_SAMPLE) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("statistic", "expected_code"),
+    [
+        (KolmogorovSmirnovHyperbolicGofStatistic, "KS_HYPERBOLIC_GOODNESS_OF_FIT"),
+        (CramerVonMisesHyperbolicGofStatistic, "CVM_HYPERBOLIC_GOODNESS_OF_FIT"),
+        (AndersonDarlingHyperbolicGofStatistic, "AD_HYPERBOLIC_GOODNESS_OF_FIT"),
+        (KuiperHyperbolicGofStatistic, "KUI_HYPERBOLIC_GOODNESS_OF_FIT"),
+        (WatsonHyperbolicGofStatistic, "WAT_HYPERBOLIC_GOODNESS_OF_FIT"),
+    ],
+)
+def test_hyperbolic_statistic_codes(statistic, expected_code):
+    """Every hyperbolic statistic should have a stable unique code."""
+    assert statistic.code() == expected_code
+
+
+@pytest.mark.parametrize(
+    "statistic",
+    [
+        CramerVonMisesHyperbolicGofStatistic(),
+        AndersonDarlingHyperbolicGofStatistic(),
+        KuiperHyperbolicGofStatistic(),
+        WatsonHyperbolicGofStatistic(),
+    ],
+)
+def test_hyperbolic_statistics_use_right_alternative(statistic):
+    """Quadratic and supremum statistics should use a right-tailed alternative."""
+    assert isinstance(statistic.alternative(), RightAlternative)
+
+
+def test_hyperbolic_criteria_are_discoverable():
+    """The public criterion registry should discover all hyperbolic statistics."""
+    codes = get_available_criteria_codes(DistributionType.HYPERBOLIC)
+    assert Counter(codes) == Counter(["KS", "CVM", "AD", "KUI", "WAT"])
+
+
+def test_hyperbolic_distribution_descriptor():
+    """The distribution registry should expose hyperbolic parameter metadata."""
+    descriptor = get_available_distribution_descriptor(DistributionType.HYPERBOLIC)
+
+    assert isinstance(descriptor, HyperbolicDistributionDescriptor)
+    assert descriptor.type() == DistributionType.HYPERBOLIC
+    assert [parameter.name for parameter in descriptor.parameters()] == [
+        "alpha",
+        "beta",
+        "delta",
+        "mu",
+    ]
+
+
+def test_hyperbolic_nan_sample_propagates():
+    """An undefined CDF value should produce an undefined statistic."""
+    result = KuiperHyperbolicGofStatistic().execute_statistic([0.0, np.nan, 1.0])
+    assert np.isnan(result)
+
+
+def test_kolmogorov_smirnov_requires_precomputed_cdf():
+    """The low-level KS entry point should require its probability array."""
+    with pytest.raises(ValueError, match="CDF values are required"):
+        KolmogorovSmirnovHyperbolicGofStatistic().do_execute_statistic(_SAMPLE)
+
+
+def test_anderson_darling_requires_log_probabilities():
+    """The low-level AD entry point should require both tail arrays."""
+    with pytest.raises(ValueError, match="Log-CDF and log-survival values are required"):
+        AndersonDarlingHyperbolicGofStatistic().do_execute_statistic(_SAMPLE)


### PR DESCRIPTION
## Summary

Added goodness-of-fit statistics for the hyperbolic distribution with Numba-optimized statistic kernels.

Part of #61.

## Changes

- Added the hyperbolic distribution type and parameter descriptor
- Added the abstract hyperbolic goodness-of-fit statistic class
- Added parameter and sample validation
- Implemented the following criteria:
  - Kolmogorov–Smirnov
  - Cramer–von Mises
  - Anderson–Darling
  - Kuiper
  - Watson
- Used SciPy to calculate the hyperbolic CDF and tail probabilities
- Added Numba-compiled kernels for calculating the statistics
- Registered the new criteria in the public API
- Added unit tests with independent NumPy/SciPy reference calculations
- Added separate benchmarks for all implemented criteria